### PR TITLE
Allow EMLECalculator to compute electrostatic contributions to energy and gradients only

### DIFF
--- a/bin/emle-server
+++ b/bin/emle-server
@@ -558,6 +558,10 @@ if args["log_file"] is None:
 if args["save_settings"] is None:
     args["save_settings"] = True
 
+# Use the default backend if no backend is specified.
+if args["backend"] is None:
+    args["backend"] = "torchani"
+
 # Use the default backend if no external backend is specified.
 if args["external_backend"] is None:
     if args["backend"] is None:


### PR DESCRIPTION
This PR adds support for using no backend for the in vacuo calculation, so that the `EMLECalculator` only returns the electrostatic contributions to the energy and gradients. This allows the calculator to be used with existing backends, e.g. those from `OpenMM-ML`.

This also fixes a small bug in the conditonal checking for the backends, where there were two consecutive `if` statements. (Ironically, this was only caught be the addition of the final `else` statement to catch the `NoneType` backend.)