### PR TITLE
Add support for gas phase simulations using sire-emle

### DIFF
--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1813,6 +1813,14 @@ class EMLECalculator:
             E_vac += delta_E
             grad_vac += delta_grad
 
+        # If there are no point charges, then just return the in vacuo energy and forces.
+        if len(charges_mm) == 0:
+            return (
+                E_vac.item() * _HARTREE_TO_KJ_MOL,
+                (-grad_vac * _HARTREE_TO_KJ_MOL * _NANOMETER_TO_BOHR).tolist(),
+                [],
+            )
+
         # Convert units.
         xyz_qm_bohr = xyz_qm * _ANGSTROM_TO_BOHR
         xyz_mm_bohr = xyz_mm * _ANGSTROM_TO_BOHR


### PR DESCRIPTION
This PR adds support for gas phase simulations when using the sire-emle OpenMM interface. If no MM point charges are passed, then the callback simply returns the in vacuo energy and forces, along with an empty list for the MM forces. Obviously the embedding method option makes no sense in this case. This is just intended to allow a user to easily perform in vacuo reference calculations with their chosen backend without needing to use OpenMM-ML.