### PR TITLE
Add link to final JCTC paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ in the near future.
 
 Further details can be found in our paper, available [here](https://pubs.acs.org/doi/10.1021/acs.jctc.4c00248). Please
 cite this work if you use `emle-engine` in your research. Supplementary
-information and data can be found [here](https://github.com/chemle/emle-engine-paper).
+information and data can be found [here](https://github.com/chemle/emle-engine-paper). For
+the original theory behind EMLE, please refer to [this](https://pubs.acs.org/doi/10.1021/acs.jctc.2c00914)
+publication.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ that no modifications to sander are needed. The embedding model currently
 supports the HCNOS elements. We plan to add support for further elements
 in the near future.
 
-Further details can be found in our preprint, available [here](https://doi.org/10.26434/chemrxiv-2023-6rng3-v2). Please
+Further details can be found in our paper, available [here](https://pubs.acs.org/doi/10.1021/acs.jctc.4c00248). Please
 cite this work if you use `emle-engine` in your research. Supplementary
 information and data can be found [here](https://github.com/chemle/emle-engine-paper).
 

--- a/bin/emle-server
+++ b/bin/emle-server
@@ -72,7 +72,7 @@ try:
     energy_frequency = int(os.getenv("EMLE_ENERGY_FREQUENCY"))
 except:
     energy_frequency = 0
-energy_file = os.getenv("EMLE_energy_file")
+energy_file = os.getenv("EMLE_ENERGY_FILE")
 log_level = os.getenv("EMLE_LOG_LEVEL")
 log_file = os.getenv("EMLE_LOG_FILE")
 save_settings = os.getenv("EMLE_SAVE_SETTINGS")

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,6 +11,7 @@ dependencies:
   - eigen
   - loguru
   - pip
+  - psutil
   - pybind11
   - pytorch
   - python < 3.11

--- a/environment_sire.yaml
+++ b/environment_sire.yaml
@@ -13,6 +13,7 @@ dependencies:
   - loguru
   - openmm >= 8.1
   - pip
+  - psutil
   - pybind11
   - pytorch
   - python < 3.11

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,15 +7,8 @@ import subprocess
 @pytest.fixture(autouse=True)
 def wrapper():
     """
-    A wrapper function that clears the environment variables before each test
-    and stops the EMLE server after each test.
+    A wrapper function stops the EMLE server after each test.
     """
-
-    # Clear the environment.
-
-    for env in os.environ:
-        if env.startswith("EMLE_"):
-            del os.environ[env]
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import subprocess
 @pytest.fixture(autouse=True)
 def wrapper():
     """
-    A wrapper function stops the EMLE server after each test.
+    A wrapper function to stop the EMLE server after each test.
     """
 
     yield

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -19,10 +19,12 @@ def test_external_local_directory():
         shutil.copyfile("tests/input/emle_sp.in", tmpdir + "/emle_sp.in")
         shutil.copyfile("tests/input/external.py", tmpdir + "/external.py")
 
+        # Copy the current environment to a new dictionary.
+        env = os.environ.copy()
+
         # Set environment variables.
-        os.environ["EMLE_PORT"] = "12345"
-        os.environ["EMLE_EXTERNAL_BACKEND"] = "external.run_external"
-        os.environ["EMLE_ENERGY_FREQUENCY"] = "1"
+        env["EMLE_EXTERNAL_BACKEND"] = "external.run_external"
+        env["EMLE_ENERGY_FREQUENCY"] = "1"
 
         # Create the sander command.
         command = "sander -O -i emle_sp.in -p adp.parm7 -c adp.rst7 -o emle.out"
@@ -32,6 +34,7 @@ def test_external_local_directory():
             cwd=tmpdir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
         )
 
         # Make sure that the process exited successfully.
@@ -53,11 +56,13 @@ def test_external_plugin_directory():
         shutil.copyfile("tests/input/adp.rst7", tmpdir + "/adp.rst7")
         shutil.copyfile("tests/input/emle_sp.in", tmpdir + "/emle_sp.in")
 
+        # Copy the current environment to a new dictionary.
+        env = os.environ.copy()
+
         # Set environment variables.
-        os.environ["EMLE_PORT"] = "12345"
-        os.environ["EMLE_EXTERNAL_BACKEND"] = "external.run_external"
-        os.environ["EMLE_PLUGIN_PATH"] = os.getcwd() + "/tests/input"
-        os.environ["EMLE_ENERGY_FREQUENCY"] = "1"
+        env["EMLE_EXTERNAL_BACKEND"] = "external.run_external"
+        env["EMLE_PLUGIN_PATH"] = os.getcwd() + "/tests/input"
+        env["EMLE_ENERGY_FREQUENCY"] = "1"
 
         # Create the sander command.
         command = "sander -O -i emle_sp.in -p adp.parm7 -c adp.rst7 -o emle.out"
@@ -67,6 +72,7 @@ def test_external_plugin_directory():
             cwd=tmpdir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
         )
 
         # Make sure that the process exited successfully.

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -43,10 +43,10 @@ def test_interpolate():
 
         assert process.returncode == 0
 
-        # Calculate the MM reference energy..
+        # Calculate the MM reference energy.
         nrg_ref = parse_mdinfo("tests/output/mdinfo_mm")
 
-        # Calculate the pure MM energy..
+        # Calculate the pure MM energy.
         nrg_mm = parse_mdinfo(tmpdir + "/mdinfo")
 
         assert math.isclose(nrg_ref, nrg_mm, rel_tol=1e-5)

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -65,13 +65,15 @@ def test_interpolate():
         )
         shutil.copyfile("tests/input/emle_sp.in", tmpdir + "/emle_sp.in")
 
+        # Copy the current environment to a new dictionary.
+        env = os.environ.copy()
+
         # Set environment variables.
-        os.environ["EMLE_PORT"] = "12345"
-        os.environ["EMLE_MM_CHARGES"] = "adp_mm_charges.txt"
-        os.environ["EMLE_LAMBDA_INTERPOLATE"] = "0"
-        os.environ["EMLE_PARM7"] = "adp_qm.parm7"
-        os.environ["EMLE_QM_INDICES"] = "adp_qm_indices.txt"
-        os.environ["EMLE_ENERGY_FREQUENCY"] = "1"
+        env["EMLE_MM_CHARGES"] = "adp_mm_charges.txt"
+        env["EMLE_LAMBDA_INTERPOLATE"] = "0"
+        env["EMLE_PARM7"] = "adp_qm.parm7"
+        env["EMLE_QM_INDICES"] = "adp_qm_indices.txt"
+        env["EMLE_ENERGY_FREQUENCY"] = "1"
 
         # Create the sander command.
         command = "sander -O -i emle_sp.in -p adp.parm7 -c adp.rst7 -o emle.out"
@@ -81,6 +83,7 @@ def test_interpolate():
             cwd=tmpdir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
         )
 
         assert process.returncode == 0
@@ -110,14 +113,16 @@ def test_interpolate_steps():
         )
         shutil.copyfile("tests/input/emle_prod.in", tmpdir + "/emle_prod.in")
 
+        # Copy the current environment to a new dictionary.
+        env = os.environ.copy()
+
         # Set environment variables.
-        os.environ["EMLE_PORT"] = "12345"
-        os.environ["EMLE_MM_CHARGES"] = "adp_mm_charges.txt"
-        os.environ["EMLE_LAMBDA_INTERPOLATE"] = "0,1"
-        os.environ["EMLE_INTERPOLATE_STEPS"] = "20"
-        os.environ["EMLE_PARM7"] = "adp_qm.parm7"
-        os.environ["EMLE_QM_INDICES"] = "adp_qm_indices.txt"
-        os.environ["EMLE_ENERGY_FREQUENCY"] = "1"
+        env["EMLE_MM_CHARGES"] = "adp_mm_charges.txt"
+        env["EMLE_LAMBDA_INTERPOLATE"] = "0,1"
+        env["EMLE_INTERPOLATE_STEPS"] = "20"
+        env["EMLE_PARM7"] = "adp_qm.parm7"
+        env["EMLE_QM_INDICES"] = "adp_qm_indices.txt"
+        env["EMLE_ENERGY_FREQUENCY"] = "1"
 
         # Create the sander command.
         command = "sander -O -i emle_prod.in -p adp.parm7 -c adp.rst7 -o emle.out"
@@ -127,6 +132,7 @@ def test_interpolate_steps():
             cwd=tmpdir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
         )
 
         assert process.returncode == 0
@@ -157,9 +163,11 @@ def test_interpolate_steps_config():
         shutil.copyfile("tests/input/emle_prod.in", tmpdir + "/emle_prod.in")
         shutil.copyfile("tests/input/config.yaml", tmpdir + "/config.yaml")
 
+        # Copy the current environment to a new dictionary.
+        env = os.environ.copy()
+
         # Set environment variables.
-        os.environ["EMLE_PORT"] = "12345"
-        os.environ["EMLE_CONFIG"] = "config.yaml"
+        env["EMLE_CONFIG"] = "config.yaml"
 
         # Create the sander command.
         command = "sander -O -i emle_prod.in -p adp.parm7 -c adp.rst7 -o emle.out"
@@ -169,6 +177,7 @@ def test_interpolate_steps_config():
             cwd=tmpdir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
         )
 
         assert process.returncode == 0

--- a/tests/test_qm_xyz.py
+++ b/tests/test_qm_xyz.py
@@ -17,9 +17,11 @@ def test_qm_xyz():
         shutil.copyfile("tests/input/adp.rst7", tmpdir + "/adp.rst7")
         shutil.copyfile("tests/input/emle_prod.in", tmpdir + "/emle_prod.in")
 
+        # Copy the current environment to a new dictionary.
+        env = os.environ.copy()
+
         # Set environment variables.
-        os.environ["EMLE_PORT"] = "12345"
-        os.environ["EMLE_QM_XYZ_FREQUENCY"] = "2"
+        env["EMLE_QM_XYZ_FREQUENCY"] = "2"
 
         # Create the sander command.
         command = "sander -O -i emle_prod.in -p adp.parm7 -c adp.rst7 -o emle.out"
@@ -29,6 +31,7 @@ def test_qm_xyz():
             cwd=tmpdir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
         )
 
         # Make sure that the process exited successfully.


### PR DESCRIPTION
This PR updates the paper link to point to the final JCTC DOI. I've also fixed a very strange issue with the unit tests where the random port number (12345) used for the unit testing no longer works. For now I've simply unset the port so that the default value is is used (10000). I'm not sure what changed to block this. Perhaps another dependency is using it, or the allowed port range for the environment has changed.