### PR TITLE
Add the MACEEMLE Torch model

### DIFF
--- a/emle/models.py
+++ b/emle/models.py
@@ -1299,6 +1299,7 @@ class MACExEMLE(EMLE):
             create_aev_calculator=True,
         )
 
+        # Load the MACE model.
         if mace_model is not None:
             if mace_model.startswith("mace-off23"):
                 size = mace_model.split("-")[-1]
@@ -1320,7 +1321,7 @@ class MACExEMLE(EMLE):
         self._mace = _e3nn_jit.compile(self._mace).to(self._dtype)
 
         # Create the z_table of the MACE model.
-        self._z_table =[int(z.item()) for z in self._mace.atomic_numbers]
+        self._z_table = [int(z.item()) for z in self._mace.atomic_numbers]
 
         if self._atomic_numbers is not None:
             # Get the node attributes.

--- a/emle/models.py
+++ b/emle/models.py
@@ -25,7 +25,7 @@
 __author__ = "Lester Hedges"
 __email__ = "lester.hedges@gmail.com"
 
-__all__ = ["EMLE", "ANI2xEMLE"]
+__all__ = ["EMLE", "ANI2xEMLE", "MACExEMLE"]
 
 import ase as _ase
 import numpy as _np
@@ -47,13 +47,26 @@ _torchani.models.BuiltinEnsemble = _torchani_patches.BuiltinEnsemble
 
 try:
     import NNPOps as _NNPOps
-
+    import NNPOps.neighbors.getNeighborPairs as _getNeighborPairs
     _NNPOps.OptimizedTorchANI = _torchani_patches.OptimizedTorchANI
 
     _has_nnpops = True
-except:
+except ImportError:
     _has_nnpops = False
-    pass
+    
+try:
+    import mace.tools as _mace_tools
+    from mace.calculators.foundations_models import mace_off as _mace_off
+
+    _has_mace = True
+except ImportError:
+    _has_mace = False
+    
+try:
+    from e3nn.util import jit as _e3nn_jit
+    _has_e3nn = True
+except ImportError:
+    _has_e3nn = False
 
 
 class EMLE(_torch.nn.Module):
@@ -925,7 +938,7 @@ class ANI2xEMLE(EMLE):
         dtype=None,
     ):
         """
-        Constructor
+        Constructor for the ANI2xEMLE class.
 
         Parameters
         ----------
@@ -1194,7 +1207,7 @@ class ANI2xEMLE(EMLE):
         if self._alpha_mode == "species":
             k = self._k[species_id]
         else:
-            k = self._gpr(aev, self._ref_mean_k, self._c_k, species_id)
+            k = self._gpr(aev, self._ref_mean_k, self._c_k, species_id) ** 2
         r_data = self._get_r_data(xyz_qm_bohr)
         mesh_data = self._get_mesh_data(xyz_qm_bohr, xyz_mm_bohr, s)
         q = self._get_q(r_data, s, chi)
@@ -1210,3 +1223,353 @@ class ANI2xEMLE(EMLE):
         E_ind = _torch.sum(vpot_ind @ charges_mm) * 0.5
 
         return _torch.stack([E_vac, E_static, E_ind])
+
+
+class MACExEMLE(EMLE):
+    def __init__(
+        self,
+        alpha_mode="species",
+        mace_model=None,
+        atomic_numbers=None,
+        device=None,
+        dtype=None,
+    ):
+        """
+        Constructor for the MACExEMLE model.
+
+        Parameters
+        ----------
+        alpha_mode: str
+            How atomic polarizabilities are calculated.
+                "species":
+                    one volume scaling factor is used for each species
+                "reference":
+                    scaling factors are obtained with GPR using the values learned
+                    for each reference environmentw
+
+        mace_model: str
+            Name of the MACE-OFF23 models to use.
+            Available models are 'mace-off23-small', 'mace-off23-medium', 'mace-off23-large'.
+            To use a locally trained MACE model, provide the path to the model file.
+            If None, the MACE-OFF23(S) model will be used by default.
+
+        atomic_numbers: torch.Tensor (N_ATOMS,)
+            List of atomic numbers to use in the MACE model.
+
+        device: torch.device
+            The device on which to run the model.
+
+        dtype: torch.dtype
+            The data type to use for the models floating point tensors.
+        """
+        if not _has_mace:
+            raise ImportError('MACE is required to use the MACExEMLE model. Install it with "pip install mace"')
+        if not _has_e3nn:
+            raise ImportError('E3NN is required to compile the MACEmodel. Install it with "pip install e3nn"')
+        if not _has_nnpops:
+            raise ImportError('NNPOps is required to use the MACExEMLE model.')
+
+        if device is not None:
+            if not isinstance(device, _torch.device):
+                raise TypeError("'device' must be of type 'torch.device'")
+        else:
+            device = _torch.get_default_device()
+
+        if dtype is not None:
+            if not isinstance(dtype, _torch.dtype):
+                raise TypeError("'dtype' must be of type 'torch.dtype'")
+        else:
+            self._dtype = _torch.get_default_dtype()
+
+        if atomic_numbers is not None:
+            if not isinstance(atomic_numbers, _torch.Tensor):
+                raise TypeError("'atomic_numbers' must be of type 'torch.Tensor'")
+            # Check that they are integers.
+            if atomic_numbers.dtype is not _torch.int64:
+                raise ValueError("'atomic_numbers' must be of dtype 'torch.int64'")
+            self._atomic_numbers = atomic_numbers.to(device)
+        else:
+            raise ValueError("Atomic numbers must be provided for the MACExEMLE model.")
+
+        # Call the base class constructor.
+        super().__init__(
+            alpha_mode=alpha_mode,
+            device=device,
+            dtype=dtype,
+            create_aev_calculator=True,
+        )
+
+        if mace_model is not None:
+            if mace_model.startswith("mace-off23"):
+                size = self.name.split("-")[-1]
+                assert (
+                    size in ["small", "medium", "large"]
+                ), f"Unsupported MACE model: '{self.name}'. Available MACE-OFF23 models are 'mace-off23-small', 'mace-off23-medium', 'mace-off23-large'"
+                self._mace = _mace_off(model=size, device=device, return_raw_model=True)
+            else:
+                # Assuming that the model is a local model.
+                if _os.path.exists(mace_model):
+                    self._mace = _torch.load(mace_model, map_location="device")
+                else:
+                    raise FileNotFoundError(f"MACE model file not found: {mace_model}")
+        else:
+            # If no MACE model is provided, use the default MACE-OFF23(S) model.
+            self._mace = _mace_off(model="small", device=device, return_raw_model=True)
+
+        # Compile the model.
+        self._mace = _e3nn_jit.compile(self._mace).to(self._dtype)
+ 
+        if self._atomic_numbers is not None:
+            # Get the node attributes.
+            node_attrs = self._get_node_attrs(self._atomic_numbers)
+            self.register_buffer(
+                "ptr",
+                _torch.tensor(
+                    [0, node_attrs.shape[0]], dtype=_torch.long, requires_grad=False
+                ),
+            )
+            self.register_buffer("node_attrs", node_attrs.to(self._dtype))
+            self.register_buffer(
+                "batch",
+                _torch.zeros(
+                    node_attrs.shape[0], dtype=_torch.long, requires_grad=False
+                ),
+            )
+
+            # No PBCs for now.
+            self.register_buffer(
+                "pbc",
+                _torch.tensor(
+                    [False, False, False], dtype=_torch.bool, requires_grad=False
+                ),
+            )
+            self.register_buffer(
+                "cell", _torch.zeros((3, 3), dtype=self._dtype, requires_grad=False)
+            )
+
+        # Assign a tensor attribute that can be used for assigning the AEVs.
+        self._aev_computer._aev = _torch.empty(0, device=device)
+
+    def _get_node_attrs(self, atomic_numbers):
+        """
+        Internal method to get the node attributes for the MACE model.
+
+        Parameters
+        ----------
+        atomic_numbers: torch.Tensor (N_ATOMS,)
+            Atomic numbers of QM atoms.
+
+        Returns
+        -------
+        node_attrs: torch.Tensor (N_ATOMS, N_FEATURES)
+            Node attributes for the MACE model.
+        """
+        z_table = _mace_tools.AtomicNumberTable(
+            [int(z) for z in self._mace.atomic_numbers]
+        )
+        return _mace_tools.to_one_hot(
+            _torch.tensor(
+                _mace_tools.atomic_numbers_to_indices(atomic_numbers, z_table=z_table),
+                dtype=_torch.long,
+            ).unsqueeze(-1),
+            num_classes=len(z_table),
+        )
+
+    def _get_neighbor_pairs(
+        self, positions: _torch.Tensor, cell: Optional[_torch.Tensor]
+    ) -> Tuple[_torch.Tensor, _torch.Tensor]:
+        """
+        Get the shifts and edge indices.
+
+        Notes
+        -----
+        This method calculates the shifts and edge indices by determining neighbor pairs (``neighbors``)
+        and respective wrapped distances (``wrappedDeltas``) using ``NNPOps.neighbors.getNeighborPairs``.
+        After obtaining the ``neighbors`` and ``wrappedDeltas``, the pairs with negative indices (r>cutoff)
+        are filtered out, and the edge indices and shifts are finally calculated.
+
+        Parameters
+        ----------
+        positions : _torch.Tensor
+            The positions of the atoms.
+        cell : _torch.Tensor
+            The cell vectors.
+
+        Returns
+        -------
+        edgeIndex : _torch.Tensor
+            The edge indices.
+        shifts : _torch.Tensor
+            The shifts.
+        """
+        # Get the neighbor pairs, shifts and edge indices.
+        neighbors, wrapped_deltas, _, _ = _getNeighborPairs(
+            positions, self._mace.r_max, -1, cell
+        )
+        mask = neighbors >= 0
+        neighbors = neighbors[mask].view(2, -1)
+        wrapped_deltas = wrapped_deltas[mask[0], :]
+
+        edge_index = _torch.hstack((neighbors, neighbors.flip(0))).to(_torch.int64)
+        if cell is not None:
+            deltas = positions[edge_index[0]] - positions[edge_index[1]]
+            wrapped_deltas = _torch.vstack((wrapped_deltas, -wrapped_deltas))
+            shifts_idx = _torch.mm(deltas - wrapped_deltas, _torch.linalg.inv(cell))
+            shifts = _torch.mm(shifts_idx, cell)
+        else:
+            shifts = _torch.zeros(
+                (edge_index.shape[1], 3), dtype=self._dtype, device=positions.device
+            )
+
+        return edge_index, shifts
+
+    def to(self, *args, **kwargs):
+        """
+        Performs Tensor dtype and/or device conversion on the model.
+        """
+        module = super(MACExEMLE, self).to(*args, **kwargs)
+        module._mace = module._mace.to(*args, **kwargs)
+        return module
+
+    def cpu(self, **kwargs):
+        """
+        Returns a copy of this model in CPU memory.
+        """
+        module = super(MACExEMLE, self).cpu(**kwargs)
+        module._mace = module._mace.cpu(**kwargs)
+        if self._atomic_numbers is not None:
+            module._atomic_numbers = module._atomic_numbers.cpu(**kwargs)
+        return module
+
+    def cuda(self, **kwargs):
+        """
+        Returns a copy of this model in CUDA memory.
+        """
+        module = super(MACExEMLE, self).cuda(**kwargs)
+        module._mace = module._mace.cuda(**kwargs)
+        if self._atomic_numbers is not None:
+            module._atomic_numbers = module._atomic_numbers.cuda(**kwargs)
+        return module
+
+    def double(self):
+        """
+        Returns a copy of this model in float64 precision.
+        """
+        module = super(MACExEMLE, self).double()
+        module._mace = module._mace.double()
+        return module
+
+    def float(self):
+        """
+        Returns a copy of this model in float32 precision.
+        """
+        module = super(MACExEMLE, self).float()
+        module._mace = module._mace.float()
+
+        return module
+
+    def forward(self, atomic_numbers, charges_mm, xyz_qm, xyz_mm):
+        """
+        Computes the static and induced EMLE energy components.
+
+        Parameters
+        ----------
+
+        atomic_numbers: torch.Tensor (N_QM_ATOMS,)
+            Atomic numbers of QM atoms.
+
+        charges_mm: torch.Tensor (max_mm_atoms,)
+            MM point charges in atomic units.
+
+        xyz_qm: torch.Tensor (N_QM_ATOMS, 3)
+            Positions of QM atoms in Angstrom.
+
+        xyz_mm: torch.Tensor (N_MM_ATOMS, 3)
+            Positions of MM atoms in Angstrom.
+
+        Returns
+        -------
+
+        result: torch.Tensor (3,)
+            The ANI2x and static and induced EMLE energy components in Hartree.
+        """
+        # Convert the atomic numbers to species IDs.
+        species_id = self._species_map[atomic_numbers]
+
+        # Reshape the IDs.
+        zid = species_id.unsqueeze(0)
+
+        # Reshape the atomic numbers.
+        atomic_numbers = atomic_numbers.unsqueeze(0)
+
+        # Reshape the coordinates,
+        xyz = xyz_qm.unsqueeze(0)
+
+        # Get the edge index and shifts for this configuration.
+        edge_index, shifts = self._get_neighbor_pairs(xyz_qm, None)
+
+        # Create the input dictionary passed to the MACE model.
+        input_dict = {
+            "ptr": self.ptr,
+            "node_attrs": self.node_attrs,
+            "batch": self.batch,
+            "pbc": self.pbc,
+            "positions": xyz_qm.to(self._dtype),
+            "edge_index": edge_index,
+            "shifts": shifts,
+            "cell": self.cell,
+        }
+
+        # Get the in vacuo energy.
+        EV_TO_HARTREE = 0.03674930495120813
+        E_vac = self._mace(input_dict, compute_force=False)["interaction_energy"]
+
+        assert (
+            E_vac is not None
+        ), "The model did not return any energy. Please check the input."
+
+        E_vac = E_vac[0] * EV_TO_HARTREE
+
+        # If there are no point charges, return the in vacuo energy and zeros
+        # for the static and induced terms.
+        if len(xyz_mm) == 0:
+            zero = _torch.tensor(0.0, dtype=xyz_qm.dtype, device=xyz_qm.device)
+            return _torch.stack([E_vac, zero, zero])
+
+        # Get the AEVs computer by the forward hook and normalise.
+        aev = self._aev_computer((zid, xyz))[1][0][:, self._aev_mask]
+        aev = aev / _torch.linalg.norm(aev, ord=2, dim=1, keepdim=True)
+
+        # Compute the MBIS valence shell widths.
+        s = self._gpr(aev, self._ref_mean_s, self._c_s, species_id)
+
+        # Compute the electronegativities.
+        chi = self._gpr(aev, self._ref_mean_chi, self._c_chi, species_id)
+
+        # Convert coordinates to Bohr.
+        ANGSTROM_TO_BOHR = 1.8897261258369282
+        xyz_qm_bohr = xyz_qm * ANGSTROM_TO_BOHR
+        xyz_mm_bohr = xyz_mm * ANGSTROM_TO_BOHR
+
+        # Compute the static energy.
+        q_core = self._q_core[species_id]
+        if self._alpha_mode == "species":
+            k = self._k[species_id]
+        else:
+            k = self._gpr(aev, self._ref_mean_k, self._c_k, species_id) ** 2
+        r_data = self._get_r_data(xyz_qm_bohr)
+        mesh_data = self._get_mesh_data(xyz_qm_bohr, xyz_mm_bohr, s)
+        q = self._get_q(r_data, s, chi)
+        q_val = q - q_core
+        mu_ind = self._get_mu_ind(r_data, mesh_data, charges_mm, s, q_val, k)
+        vpot_q_core = self._get_vpot_q(q_core, mesh_data[0])
+        vpot_q_val = self._get_vpot_q(q_val, mesh_data[1])
+        vpot_static = vpot_q_core + vpot_q_val
+        E_static = _torch.sum(vpot_static @ charges_mm)
+
+        # Compute the induced energy.
+        vpot_ind = self._get_vpot_mu(mu_ind, mesh_data[2])
+        E_ind = _torch.sum(vpot_ind @ charges_mm) * 0.5
+
+        return _torch.stack([E_vac, E_static, E_ind])
+

--- a/emle/models.py
+++ b/emle/models.py
@@ -1301,10 +1301,10 @@ class MACExEMLE(EMLE):
 
         if mace_model is not None:
             if mace_model.startswith("mace-off23"):
-                size = self.name.split("-")[-1]
+                size = mace_model.split("-")[-1]
                 assert (
                     size in ["small", "medium", "large"]
-                ), f"Unsupported MACE model: '{self.name}'. Available MACE-OFF23 models are 'mace-off23-small', 'mace-off23-medium', 'mace-off23-large'"
+                ), f"Unsupported MACE model: '{mace_model}'. Available MACE-OFF23 models are 'mace-off23-small', 'mace-off23-medium', 'mace-off23-large'"
                 self._mace = _mace_off(model=size, device=device, return_raw_model=True)
             else:
                 # Assuming that the model is a local model.


### PR DESCRIPTION
This PR adds the `MACExEMLE` module to the current collection of Torch modules that can be used for the calculation of electrostatic embedding.

The only difference in usage relative to the `ANI2xEMLE` module is that `atomic_numbers` must be provided during initialization. This is necessary because the functions provided by the mace package to create node attributes from atomic numbers cannot be converted into a TorchScript module. If I find a TorchScript-compliant solution for this, I will update the implementation.

Additionally, currently the code assumes no PBC. However, adapting the code to include PBC would be relatively straightforward, as the `_get_neighbor_pairs` method can already handle this. 