### PR TITLE
Refactor calculator to use EMLE Torch module

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ To stop the server:
 emle-stop
 ```
 
+## NNPOps
+
+The ``EMLE`` model uses Atomic Environment Vectors (AEVs) for the calculation of
+the electrostatic embedding energy. For performance, it is desirable to use
+the optimised symmetry functions provided by the [NNPOps](https://github.com/openmm/NNPOps)
+package. This requires a *static* compute graph, so needs to know the atomic
+numbers for the atoms in the QM region in advance. These can be specified using
+the ``EMLE_ATOMIC_NUMBERS`` environment variable, or the ``--atomic-numbers``
+command-line argument when launching the server. This option should only be
+used if the QM region is fixed, i.e. the atoms in the QM region do not change
+each time the calculator is called.
+
 ## Backends
 
 The embedding method relies on in vacuo energies and gradients, to which

--- a/bin/emle-server
+++ b/bin/emle-server
@@ -64,6 +64,7 @@ except:
     species = None
 method = os.getenv("EMLE_METHOD")
 alpha_mode = os.getenv("EMLE_ALPHA_MODE")
+atomic_numbers = os.getenv("EMLE_ATOMIC_NUMBERS")
 mm_charges = os.getenv("EMLE_MM_CHARGES")
 try:
     num_clients = int(os.getenv("EMLE_NUM_CLIENTS"))
@@ -136,6 +137,7 @@ env = {
     "species": species,
     "method": method,
     "alpha_mode": alpha_mode,
+    "atomic_numbers": atomic_numbers,
     "mm_charges": mm_charges,
     "num_clients": num_clients,
     "backend": backend,
@@ -208,6 +210,13 @@ parser.add_argument(
     type=str,
     help="the alpha mode to use for the embedding method",
     choices=["species", "reference"],
+    required=False,
+)
+parser.add_argument(
+    "--atomic-numbers",
+    type=str,
+    nargs="*",
+    help="the atomic numbers of the atoms in the qm region",
     required=False,
 )
 parser.add_argument(
@@ -479,6 +488,38 @@ if set_lambda_interpolate is not None:
 
 
 # Handle special case formatting for environment variables.
+
+# Validate the atomic numbers.
+if args["atomic_numbers"] is not None:
+    # Whether we are parsing a list of atomic numbers, rather than a file.
+    is_list = False
+
+    if isinstance(args["atomic_numbers"], str):
+        # If this isn't a path to a file, try splitting on commas.
+        if not os.path.isfile(args["atomic_numbers"]) or not os.path.isfile(
+            os.path.abspath(args["atomic_numbers"])
+        ):
+            try:
+                args["atomic_numbers"] = args["atomic_numbers"].split(",")
+                is_list = True
+            except:
+                raise ValueError(
+                    "Unable to parse EMLE_ATOMIC_NUMBERS environment variable as a comma-separated list of ints"
+                )
+
+    # A single entry list is assumed to be the path to a file.
+    elif isinstance(args["atomic_numbers"], list):
+        if len(args["atomic_numbers"]) == 1:
+            args["atomic_numbers"] = args["atomic_numbers"][0]
+        else:
+            is_list = True
+
+    # Try to parse lists of atomic numbers into a list of ints.
+    if is_list:
+        try:
+            args["atomic_numbers"] = [int(x) for x in args["atomic_numbers"]]
+        except:
+            raise TypeError("Unable to parse atomic numbers as a list of ints")
 
 # Validate the MM charges.
 if args["mm_charges"] is None:

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -418,6 +418,7 @@ class EMLECalculator:
         self._emle = _EMLE(
             model=model,
             method=method,
+            species=species,
             alpha_mode=alpha_mode,
             atomic_numbers=atomic_numbers,
             mm_charges=self._mm_charges,
@@ -794,6 +795,7 @@ class EMLECalculator:
             # Create an MM EMLE model for interpolation.
             self._emle_mm = _EMLE(
                 model=model,
+                species=species,
                 alpha_mode=alpha_mode,
                 atomic_numbers=atomic_numbers,
                 method="mm",

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -46,170 +46,14 @@ import ase.io as _ase_io
 
 import torch as _torch
 
-_ANGSTROM_TO_BOHR = 1.0 / _ase.units.Bohr
+from .models import EMLE as _EMLE
+
 _NANOMETER_TO_BOHR = 10.0 / _ase.units.Bohr
 _BOHR_TO_ANGSTROM = _ase.units.Bohr
 _EV_TO_HARTREE = 1.0 / _ase.units.Hartree
 _KCAL_MOL_TO_HARTREE = 1.0 / _ase.units.Hartree * _ase.units.kcal / _ase.units.mol
 _HARTREE_TO_KJ_MOL = _ase.units.Hartree / _ase.units.kJ * _ase.units.mol
 _NANOMETER_TO_ANGSTROM = 10.0
-
-
-class _AEVCalculator:
-    """
-    Calculates AEV feature vectors for a given system
-    """
-
-    def __init__(self, aev_computer, aev_mask):
-        """
-        Constructor
-
-        Parameters
-        ----------
-
-        aev_computer: torchani.aev.AEVComputer
-            Computer for AEV features.
-
-        aev_mask: torch.tensor (N_REF, )
-            The mask for the AEV features.
-        """
-        self._aev_computer = aev_computer
-        self._aev_mask = aev_mask
-
-    def __call__(self, zid, xyz):
-        """
-        Calculates the AEV feature vectors for a given molecule.
-
-        Parameters
-        ----------
-
-        zid: numpy.array (N_ATOMS)
-            Chemical species indices for each atom.
-
-        xyz: torch.tensor (N_ATOMS, 3)
-            Atomic positions in Bohr.
-
-        Returns
-        -------
-
-        aev: torch.tensor (N_ATOMS, N_AEV)
-            AEV feature vectors for each atom.
-        """
-
-        # Reshape the species indices.
-        zid = zid.reshape(1, *zid.shape)
-
-        # Reshape the atomic positions and convert to Angstrom.
-        xyz = xyz.reshape(1, *xyz.shape) * _BOHR_TO_ANGSTROM
-
-        # Compute the AEVs.
-        aev = self._aev_computer((zid, xyz))[1][0][:, self._aev_mask]
-        return aev / _torch.linalg.norm(aev, axis=1, keepdims=True)
-
-
-class _GPRCalculator:
-    """Predicts an atomic property for a molecule with Gaussian Process Regression (GPR)."""
-
-    def __init__(self, ref_values, ref_features, n_ref, sigma, device):
-        """
-        Constructor
-
-        Parameters
-        ----------
-
-        ref_values: numpy.array (N_Z, N_REF)
-            The property values corresponding to the basis vectors for each species.
-
-        ref_features: numpy.array (N_Z, N_REF, N_FEAT)
-            The basis feature vectors for each species.
-
-        n_ref: (N_Z,)
-            Number of supported species.
-
-        sigma: float
-            The uncertainty of the observations (regularizer).
-
-        device: torch device
-            The PyTorch device to use for calculations.
-        """
-        # Store the device and reference features.
-        self._device = device
-        self._ref_features = ref_features
-
-        # Compute the inverse of the K matrix.
-        Kinv = _torch.tensor(
-            self._get_Kinv(ref_features, sigma),
-            dtype=_torch.float32,
-            device=self._device,
-        )
-
-        # Store additional attributes for the GPR model.
-        self._n_ref = n_ref
-        self._n_z = len(n_ref)
-        self._ref_mean = _np.sum(ref_values, axis=1) / n_ref
-        ref_shifted = _torch.tensor(
-            ref_values - self._ref_mean[:, None],
-            dtype=_torch.float32,
-            device=self._device,
-        )
-        self._c = (Kinv @ ref_shifted[:, :, None]).squeeze()
-
-    def __call__(self, mol_features, zid):
-        """
-
-        Parameters
-        ----------
-
-        mol_features: numpy.array (N_ATOMS, N_FEAT)
-            The feature vectors for each atom.
-
-        zid: torch.tensor (N_ATOMS,)
-            The species identity value of each atom.
-
-        Returns
-        -------
-
-        result: torch.tensor, numpy.array (N_ATOMS)
-            The values of the predicted property for each atom.
-        """
-
-        result = _torch.zeros(len(zid), dtype=_torch.float32, device=self._device)
-        for i in range(self._n_z):
-            n_ref = self._n_ref[i]
-            ref_features_z = _torch.tensor(
-                self._ref_features[i, :n_ref], dtype=_torch.float32, device=self._device
-            )
-            mol_features_z = mol_features[zid == i, :, None]
-
-            K_mol_ref2 = (ref_features_z @ mol_features_z) ** 2
-            K_mol_ref2 = K_mol_ref2.reshape(K_mol_ref2.shape[:-1])
-            result[zid == i] = K_mol_ref2 @ self._c[i, :n_ref] + self._ref_mean[i]
-
-        return result
-
-    @classmethod
-    def _get_Kinv(cls, ref_features, sigma):
-        """
-        Internal function to compute the inverse of the K matrix for GPR.
-
-        Parameters
-        ----------
-
-        ref_features: numpy.array (N_Z, MAX_N_REF, N_FEAT)
-            The basis feature vectors for each species.
-
-        sigma: float
-            The uncertainty of the observations (regularizer).
-
-        Returns
-        -------
-
-        result: numpy.array (MAX_N_REF, MAX_N_REF)
-            The inverse of the K matrix.
-        """
-        n = ref_features.shape[1]
-        K = (ref_features @ ref_features.swapaxes(1, 2)) ** 2
-        return _np.linalg.inv(K + sigma**2 * _np.eye(n, dtype=_np.float32))
 
 
 class EMLECalculator:
@@ -300,6 +144,7 @@ class EMLECalculator:
 
         species: List[int]
             List of species (atomic numbers) supported by the EMLE model. If
+            None, then the default species list will be used.
 
         method: str
             The desired embedding method. Options are:
@@ -339,7 +184,7 @@ class EMLECalculator:
         plugin_path: str
             The direcory containing any scripts used for external backends.
 
-        mm_charges: numpy.array, str
+        mm_charges: List, Tuple, numpy.ndarray, str
             An array of MM charges for atoms in the QM region. This is required
             when the embedding method is "mm". Alternatively, pass the path to
             a file containing the charges. The file should contain a single
@@ -563,6 +408,9 @@ class EMLECalculator:
         self._method = method
 
         if mm_charges is not None:
+            # Convert lists/tuples to NumPy arrays.
+            if isinstance(mm_charges, (list, tuple)):
+                mm_charges = _np.array(mm_charges)
             if isinstance(mm_charges, _np.ndarray):
                 if mm_charges.dtype != _np.float64:
                     msg = "'mm_charges' must have dtype 'float64'"
@@ -596,6 +444,8 @@ class EMLECalculator:
                 msg = "'mm_charges' must be of type 'numpy.ndarray' or 'str'"
                 _logger.error(msg)
                 raise TypeError(msg)
+        else:
+            self._mm_charges = None
 
         if self._method == "mm":
             # Make sure MM charges have been passed for the QM region.
@@ -896,6 +746,44 @@ class EMLECalculator:
             restart = False
         self._restart = restart
 
+        # Validate the PyTorch device.
+        if device is not None:
+            if not isinstance(device, str):
+                msg = "'device' must be of type 'str'"
+                _logger.error(msg)
+                raise TypeError(msg)
+            # Strip whitespace and convert to lower case.
+            device = device.lower().replace(" ", "")
+            # See if the user has specified a GPU index.
+            if device.startswith("cuda"):
+                try:
+                    device, index = device.split(":")
+                except:
+                    index = 0
+
+                # Make sure the GPU device index is valid.
+                try:
+                    index = int(index)
+                except:
+                    msg = f"Invalid GPU index: {index}"
+                    _logger.error(msg)
+                    raise ValueError(msg)
+
+            if not device in self._supported_devices:
+                msg = f"Unsupported device '{device}'. Options are: {', '.join(self._supported_devices)}"
+                _logger.error(msg)
+                raise ValueError(msg)
+            # Create the full CUDA device string.
+            if device == "cuda":
+                device = f"cuda:{index}"
+            # Set the device.
+            self._device = _torch.device(device)
+        else:
+            # Default to CUDA, if available.
+            self._device = _torch.device(
+                "cuda" if _torch.cuda.is_available() else "cpu"
+            )
+
         # Validate the interpolation lambda parameter.
         if lambda_interpolate is not None:
             if self._backend == "rascal":
@@ -977,46 +865,17 @@ class EMLECalculator:
                         raise ValueError(msg)
                     self._interpolate_steps = interpolate_steps
 
+            # Create an MM EMLE model for interpolation.
+            self._emle_mm = _EMLE(
+                model=self._model,
+                alpha_mode=self._alpha_mode,
+                method="mm",
+                mm_charges=self._mm_charges,
+                device=self._device,
+            )
+
         else:
             self._is_interpolate = False
-
-        # Validate the PyTorch device.
-        if device is not None:
-            if not isinstance(device, str):
-                msg = "'device' must be of type 'str'"
-                _logger.error(msg)
-                raise TypeError(msg)
-            # Strip whitespace and convert to lower case.
-            device = device.lower().replace(" ", "")
-            # See if the user has specified a GPU index.
-            if device.startswith("cuda"):
-                try:
-                    device, index = device.split(":")
-                except:
-                    index = 0
-
-                # Make sure the GPU device index is valid.
-                try:
-                    index = int(index)
-                except:
-                    msg = f"Invalid GPU index: {index}"
-                    _logger.error(msg)
-                    raise ValueError(msg)
-
-            if not device in self._supported_devices:
-                msg = f"Unsupported device '{device}'. Options are: {', '.join(self._supported_devices)}"
-                _logger.error(msg)
-                raise ValueError(msg)
-            # Create the full CUDA device string.
-            if device == "cuda":
-                device = f"cuda:{index}"
-            # Set the device.
-            self._device = _torch.device(device)
-        else:
-            # Default to CUDA, if available.
-            self._device = _torch.device(
-                "cuda" if _torch.cuda.is_available() else "cpu"
-            )
 
         if energy_frequency is None:
             energy_frequency = 0
@@ -1139,9 +998,6 @@ class EMLECalculator:
 
             self._orca_path = abs_orca_path
 
-        # Re-use the existing AEV computer from TorchANI.
-        if self._backend == "torchani":
-            self._aev_computer = self._torchani_model.aev_computer
         # Create a new AEV computer.
         else:
             import torchani as _torchani
@@ -1149,75 +1005,15 @@ class EMLECalculator:
             ani2x = _torchani.models.ANI2x(periodic_table_index=True).to(self._device)
             self._aev_computer = ani2x.aev_computer
 
-        # Create the AEVCaclulator.
-        aev_mask = _torch.tensor(
-            self._params["aev_mask"], dtype=_torch.bool, device=self._device
-        )
-        self._get_features = _AEVCalculator(self._aev_computer, aev_mask)
-
-        self._q_core = _torch.tensor(
-            self._params["q_core"], dtype=_torch.float32, device=self._device
-        )
-        if self._method == "mm" or self._is_interpolate:
-            self._q_core_mm = _torch.tensor(
-                self._mm_charges, dtype=_torch.float32, device=self._device
-            )
-        self._a_QEq = self._params["a_QEq"]
-        self._a_Thole = self._params["a_Thole"]
-        if self._alpha_mode == "species":
-            try:
-                self._k_Z = _torch.tensor(
-                    self._params["k_Z"], dtype=_torch.float32, device=self._device
-                )
-            except:
-                msg = (
-                    "Missing 'k_Z' key in model. This is required when "
-                    "using 'species' alpha mode."
-                )
-                _logger.error(msg)
-                raise ValueError(msg)
-        else:
-            try:
-                self.sqrtk_ref = _torch.tensor(
-                    self._params["sqrtk_ref"], dtype=_torch.float32, device=self._device
-                )
-            except:
-                msg = (
-                    "Missing 'sqrtk_ref' key in model. This is required when "
-                    "using 'reference' alpha mode."
-                )
-                _logger.error(msg)
-                raise ValueError(msg)
-
-        self._q_total = _torch.tensor(
-            self._params.get("total_charge", 0),
-            dtype=_torch.float32,
+        # Create the EMLE model.
+        self._emle = _EMLE(
+            model=self._model,
+            method=self._method,
+            mm_charges=self._mm_charges,
             device=self._device,
         )
-        self._get_s = _GPRCalculator(
-            self._params["s_ref"],
-            self._params["ref_aev"],
-            self._params["n_ref"],
-            1e-3,
-            self._device,
-        )
-        self._get_chi = _GPRCalculator(
-            self._params["chi_ref"],
-            self._params["ref_aev"],
-            self._params["n_ref"],
-            1e-3,
-            self._device,
-        )
-        if self._alpha_mode == "reference":
-            self._get_sqrtk = _GPRCalculator(
-                self._params["sqrtk_ref"],
-                self._params["ref_aev"],
-                self._params["n_ref"],
-                1e-3,
-                self._device,
-            )
 
-        # Initialise the maximum number of MM atom that have been seen.
+        # Intialise the maximum number of MM atoms that have been seen.
         self._max_mm_atoms = 0
 
         # Initialise the number of steps. (Calls to the calculator.)
@@ -1304,7 +1100,7 @@ class EMLECalculator:
             xyz_mm,
             charges_mm,
             xyz_file_qm,
-        ) = self.parse_orca_input(orca_input)
+        ) = self._parse_orca_input(orca_input)
 
         # Make sure that the number of QM atoms matches the number of MM charges
         # when using mm embedding.
@@ -1442,31 +1238,30 @@ class EMLECalculator:
             E_vac += delta_E
             grad_vac += delta_grad
 
-        # Convert units.
-        xyz_qm_bohr = xyz_qm * _ANGSTROM_TO_BOHR
-        xyz_mm_bohr = xyz_mm * _ANGSTROM_TO_BOHR
+        # Store a copy of the QM coordinates as a NumPy array.
+        xyz_qm_np = xyz_qm
 
         # Convert inputs to Torch tensors.
-        xyz_qm_bohr = _torch.tensor(
-            xyz_qm_bohr, dtype=_torch.float32, device=self._device, requires_grad=True
+        xyz_qm = _torch.tensor(
+            xyz_qm, dtype=_torch.float32, device=self._device, requires_grad=True
         )
-        xyz_mm_bohr = _torch.tensor(
-            xyz_mm_bohr, dtype=_torch.float32, device=self._device, requires_grad=True
+        xyz_mm = _torch.tensor(
+            xyz_mm, dtype=_torch.float32, device=self._device, requires_grad=True
         )
         charges_mm = _torch.tensor(
             charges_mm, dtype=_torch.float32, device=self._device
         )
 
         # Compute energy and gradients.
-        E = self._get_E(charges_mm, xyz_qm_bohr, xyz_mm_bohr)
+        E = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
         dE_dxyz_qm_bohr, dE_dxyz_mm_bohr = _torch.autograd.grad(
-            E, (xyz_qm_bohr, xyz_mm_bohr)
+            E.sum(), (xyz_qm, xyz_mm)
         )
         dE_dxyz_qm_bohr = dE_dxyz_qm_bohr.cpu().numpy()
         dE_dxyz_mm_bohr = dE_dxyz_mm_bohr.cpu().numpy()
 
         # Compute the total energy and gradients.
-        E_tot = E_vac + E.detach().cpu().numpy()
+        E_tot = E_vac + E.sum().detach().cpu().numpy()
         grad_qm = dE_dxyz_qm_bohr + grad_vac
         grad_mm = dE_dxyz_mm_bohr
 
@@ -1484,23 +1279,16 @@ class EMLECalculator:
             else:
                 E_mm_qm_vac, grad_mm_qm_vac = 0.0, _np.zeros_like(xyz_qm)
 
-            # Swap the method to MM.
-            method = self._method
-            self._method = "mm"
-
-            # Recompute the energy and gradients.
-            E = self._get_E(charges_mm, xyz_qm_bohr, xyz_mm_bohr)
+            # Compute the embedding contributions.
+            E = self._emle_mm(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
             dE_dxyz_qm_bohr, dE_dxyz_mm_bohr = _torch.autograd.grad(
-                E, (xyz_qm_bohr, xyz_mm_bohr)
+                E.sum(), (xyz_qm, xyz_mm)
             )
             dE_dxyz_qm_bohr = dE_dxyz_qm_bohr.cpu().numpy()
             dE_dxyz_mm_bohr = dE_dxyz_mm_bohr.cpu().numpy()
 
-            # Restore the method.
-            self._method = method
-
             # Store the the MM and EMLE energies. The MM energy is an approximation.
-            E_mm = E_mm_qm_vac + E.detach().cpu().numpy()
+            E_mm = E_mm_qm_vac + E.sum().detach().cpu().numpy()
             E_emle = E_tot
 
             # Work out the current value of lambda.
@@ -1570,7 +1358,7 @@ class EMLECalculator:
 
         # Write out the QM region to the xyz trajectory file.
         if self._qm_xyz_frequency > 0 and self._step % self._qm_xyz_frequency == 0:
-            atoms = _ase.Atoms(positions=xyz_qm, numbers=atomic_numbers)
+            atoms = _ase.Atoms(positions=xyz_qm_np, numbers=atomic_numbers)
             if hasattr(self, "_max_f_std"):
                 atoms.info = {"max_f_std": self._max_f_std}
             _ase_io.write(self._qm_xyz_file, atoms, append=True)
@@ -1839,42 +1627,38 @@ class EMLECalculator:
                 [],
             )
 
-        # Convert units.
-        xyz_qm_bohr = xyz_qm * _ANGSTROM_TO_BOHR
-        xyz_mm_bohr = xyz_mm * _ANGSTROM_TO_BOHR
-
         # Convert inputs to Torch tensors.
-        xyz_qm_bohr = _torch.tensor(
-            xyz_qm_bohr, dtype=_torch.float32, device=self._device, requires_grad=True
+        xyz_qm = _torch.tensor(
+            xyz_qm, dtype=_torch.float32, device=self._device, requires_grad=True
         )
-        xyz_mm_bohr = _torch.tensor(
-            xyz_mm_bohr, dtype=_torch.float32, device=self._device, requires_grad=True
+        xyz_mm = _torch.tensor(
+            xyz_mm, dtype=_torch.float32, device=self._device, requires_grad=True
         )
         charges_mm = _torch.tensor(
             charges_mm, dtype=_torch.float32, device=self._device
         )
 
         # Compute energy and gradients.
-        E = self._get_E(charges_mm, xyz_qm_bohr, xyz_mm_bohr)
+        E = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
         dE_dxyz_qm_bohr, dE_dxyz_mm_bohr = _torch.autograd.grad(
-            E, (xyz_qm_bohr, xyz_mm_bohr)
+            E.sum(), (xyz_qm, xyz_mm)
         )
         dE_dxyz_qm_bohr = dE_dxyz_qm_bohr.cpu().numpy()
         dE_dxyz_mm_bohr = dE_dxyz_mm_bohr.cpu().numpy()
 
         # Compute the total energy and gradients.
-        E_tot = E_vac + E.detach().cpu().numpy()
+        E_tot = E_vac + E.sum().detach().cpu().numpy()
         grad_qm = dE_dxyz_qm_bohr + grad_vac
         grad_mm = dE_dxyz_mm_bohr
 
         # Interpolate between the MM and ML/MM potential.
         if self._is_interpolate:
+            # Create the ASE atoms object if it wasn't already created by the backend.
+            if atoms is None:
+                atoms = _ase.Atoms(positions=xyz_qm, numbers=atomic_numbers)
+
             # Compute the in vacuo MM energy and gradients for the QM region.
             if self._backend != None:
-                # Create the ASE atoms object if it wasn't already created by the backend.
-                if atoms is None:
-                    atoms = _ase.Atoms(positions=xyz_qm, numbers=atomic_numbers)
-
                 E_mm_qm_vac, grad_mm_qm_vac = self._run_pysander(
                     atoms=atoms,
                     parm7=self._parm7,
@@ -1885,23 +1669,16 @@ class EMLECalculator:
             else:
                 E_mm_qm_vac, grad_mm_qm_vac = 0.0, _np.zeros_like(xyz_qm)
 
-            # Swap the method to MM.
-            method = self._method
-            self._method = "mm"
-
-            # Recompute the energy and gradients.
-            E = self._get_E(charges_mm, xyz_qm_bohr, xyz_mm_bohr)
+            # Compute the embedding contributions.
+            E = self._emle_mm(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
             dE_dxyz_qm_bohr, dE_dxyz_mm_bohr = _torch.autograd.grad(
-                E, (xyz_qm_bohr, xyz_mm_bohr)
+                E.sum(), (xyz_qm, xyz_mm)
             )
             dE_dxyz_qm_bohr = dE_dxyz_qm_bohr.cpu().numpy()
             dE_dxyz_mm_bohr = dE_dxyz_mm_bohr.cpu().numpy()
 
-            # Restore the method.
-            self._method = method
-
             # Store the the MM and EMLE energies. The MM energy is an approximation.
-            E_mm = E_mm_qm_vac + E.detach().cpu().numpy()
+            E_mm = E_mm_qm_vac + E.sum().detach().cpu().numpy()
             E_emle = E_tot
 
             # Work out the current value of lambda.
@@ -2087,505 +1864,8 @@ class EMLECalculator:
 
         return E, force_qm, force_mm
 
-    def _get_E(self, charges_mm, xyz_qm_bohr, xyz_mm_bohr):
-        """
-        Computes total EMLE embedding energy (sum of static and induced).
-
-        Parameters
-        ----------
-
-        charges_mm: torch.tensor (max_mm_atoms,)
-            MM point charges in atomic units, padded to max_mm_atoms with zeros.
-
-        xyz_qm_bohr: torch.tensor (N_ATOMS, 3)
-            Positions of QM atoms (in Bohr).
-
-        xyz_mm_bohr: torch.tensor (max_mm_atoms, 3)
-            Positions of MM atoms (in Bohr), padded to max_mm_atoms with zeros.
-
-        Returns
-        -------
-
-        result: torch.tensor (1,)
-            Total EMLE embedding energy.
-        """
-        return _torch.sum(self._get_E_components(charges_mm, xyz_qm_bohr, xyz_mm_bohr))
-
-    def _get_E_components(self, charges_mm, xyz_qm_bohr, xyz_mm_bohr):
-        """
-        Computes EMLE energy components
-
-        Parameters
-        ----------
-
-        charges_mm: torch.tensor (max_mm_atoms,)
-            MM point charges in atomic units, padded to max_mm_atoms with zeros.
-
-        xyz_qm_bohr: torch.tensor (N_ATOMS, 3)
-            Positions of QM atoms (in Bohr).
-
-        xyz_mm_bohr: torch.tensor (max_mm_atoms, 3)
-            Positions of MM atoms (in Bohr), padded to max_mm_atoms with zeros.
-
-        Returns
-        -------
-
-        result: torch.tensor (2,)
-            Values of static and induced EMLE energy components.
-        """
-
-        # Get the features.
-        mol_features = self._get_features(self._species_id, xyz_qm_bohr)
-
-        # Compute the MBIS valence shell widths.
-        s = self._get_s(mol_features, self._species_id)
-
-        # Compute the electronegativities.
-        chi = self._get_chi(mol_features, self._species_id)
-
-        if self._method != "mm":
-            q_core = self._q_core[self._species_id]
-        else:
-            q_core = self._q_core_mm
-
-        if self._alpha_mode == "species":
-            k = self._k_Z[self._species_id]
-        else:
-            k = self._get_sqrtk(mol_features, self._species_id) ** 2
-
-        r_data = self._get_r_data(xyz_qm_bohr, self._device)
-        mesh_data = self._get_mesh_data(xyz_qm_bohr, xyz_mm_bohr, s)
-        if self._method in ["electrostatic", "nonpol"]:
-            q = self._get_q(r_data, s, chi)
-            q_val = q - q_core
-        elif self._method == "mechanical":
-            q_core = self._get_q(r_data, s, chi)
-            q_val = _torch.zeros_like(q_core, dtype=_torch.float32, device=self._device)
-        else:
-            q_val = _torch.zeros_like(q_core, dtype=_torch.float32, device=self._device)
-        vpot_q_core = self._get_vpot_q(q_core, mesh_data["T0_mesh"])
-        vpot_q_val = self._get_vpot_q(q_val, mesh_data["T0_mesh_slater"])
-        vpot_static = vpot_q_core + vpot_q_val
-        E_static = _torch.sum(vpot_static @ charges_mm)
-
-        if self._method == "electrostatic":
-            mu_ind = self._get_mu_ind(r_data, mesh_data, charges_mm, s, q_val, k)
-            vpot_ind = self._get_vpot_mu(mu_ind, mesh_data["T1_mesh"])
-            E_ind = _torch.sum(vpot_ind @ charges_mm) * 0.5
-        else:
-            E_ind = _torch.tensor(0.0, dtype=_torch.float32, device=self._device)
-
-        return _torch.stack([E_static, E_ind])
-
-    def _get_q(self, r_data, s, chi):
-        """
-        Internal method that predicts MBIS charges
-        (Eq. 16 in 10.1021/acs.jctc.2c00914)
-
-        Parameters
-        ----------
-
-        r_data: r_data object (output of self._get_r_data)
-
-        s: torch.tensor (N_ATOMS,)
-            MBIS valence shell widths.
-
-        chi: torch.tensor (N_ATOMS,)
-            Electronegativities.
-
-        Returns
-        -------
-
-        result: torch.tensor (N_ATOMS,)
-            Predicted MBIS charges.
-        """
-        A = self._get_A_QEq(r_data, s)
-        b = _torch.hstack([-chi, self._q_total])
-        return _torch.linalg.solve(A, b)[:-1]
-
-    def _get_A_QEq(self, r_data, s):
-        """
-        Internal method, generates A matrix for charge prediction
-        (Eq. 16 in 10.1021/acs.jctc.2c00914)
-
-        Parameters
-        ----------
-
-        r_data: r_data object (output of self._get_r_data)
-
-        s: torch.tensor (N_ATOMS,)
-            MBIS valence shell widths.
-
-        Returns
-        -------
-
-        result: torch.tensor (N_ATOMS + 1, N_ATOMS + 1)
-        """
-        s_gauss = s * self._a_QEq
-        s2 = s_gauss**2
-        s_mat = _torch.sqrt(s2[:, None] + s2[None, :])
-
-        A = self._get_T0_gaussian(r_data["T01"], r_data["r_mat"], s_mat)
-
-        new_diag = _torch.ones_like(
-            A.diagonal(), dtype=_torch.float32, device=self._device
-        ) * (1.0 / (s_gauss * _np.sqrt(_np.pi)))
-        mask = _torch.diag(
-            _torch.ones_like(new_diag, dtype=_torch.float32, device=self._device)
-        )
-        A = mask * _torch.diag(new_diag) + (1.0 - mask) * A
-
-        # Store the dimensions of A.
-        x, y = A.shape
-
-        # Create an tensor of ones with one more row and column than A.
-        B = _torch.ones(x + 1, y + 1, dtype=_torch.float32, device=self._device)
-
-        # Copy A into B.
-        B[:x, :y] = A
-
-        # Set the final entry on the diagonal to zero.
-        B[-1, -1] = 0.0
-
-        return B
-
-    def _get_mu_ind(self, r_data, mesh_data, q, s, q_val, k):
-        """
-        Internal method, calculates induced atomic dipoles
-        (Eq. 20 in 10.1021/acs.jctc.2c00914)
-
-        Parameters
-        ----------
-
-        r_data: r_data object (output of self._get_r_data)
-
-        mesh_data: mesh_data object (output of self._get_mesh_data)
-
-        q: torch.tensor (max_mm_atoms,)
-            MM point charges, padded to max_mm_atoms with zeros.
-
-        s: torch.tensor (N_ATOMS,)
-            MBIS valence shell widths.
-
-        q_val: torch.tensor (N_ATOMS,)
-            MBIS valence charges.
-
-        k: torch.tensor (N_Z)
-            Scaling factors for polarizabilities.
-
-        Returns
-        -------
-
-        result: torch.tensor (N_ATOMS, 3)
-            Array of induced dipoles
-        """
-        A = self._get_A_thole(r_data, s, q_val, k)
-
-        r = 1.0 / mesh_data["T0_mesh"]
-        f1 = self._get_f1_slater(r, s[:, None] * 2.0)
-        fields = _torch.sum(
-            mesh_data["T1_mesh"] * f1[:, :, None] * q[:, None], axis=1
-        ).flatten()
-
-        mu_ind = _torch.linalg.solve(A, fields)
-        return mu_ind.reshape((-1, 3))
-
-    def _get_A_thole(self, r_data, s, q_val, k):
-        """
-        Internal method, generates A matrix for induced dipoles prediction
-        (Eq. 20 in 10.1021/acs.jctc.2c00914)
-
-        Parameters
-        ----------
-
-        r_data: r_data object (output of self._get_r_data)
-
-        s: torch.tensor (N_ATOMS,)
-            MBIS valence shell widths.
-
-        q_val: torch.tensor (N_ATOMS,)
-            MBIS charges.
-
-        k: torch.tensor (N_Z)
-            Scaling factors for polarizabilities.
-
-        Returns
-        -------
-
-        result: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-            The A matrix for induced dipoles prediction.
-        """
-        v = -60 * q_val * s**3
-        alpha = v * k
-
-        alphap = alpha * self._a_Thole
-        alphap_mat = alphap[:, None] * alphap[None, :]
-
-        au3 = r_data["r_mat"] ** 3 / _torch.sqrt(alphap_mat)
-        au31 = au3.repeat_interleave(3, dim=1)
-        au32 = au31.repeat_interleave(3, dim=0)
-
-        A = -self._get_T2_thole(r_data["T21"], r_data["T22"], au32)
-
-        new_diag = 1.0 / alpha.repeat_interleave(3)
-        mask = _torch.diag(
-            _torch.ones_like(new_diag, dtype=_torch.float32, device=self._device)
-        )
-        A = mask * _torch.diag(new_diag) + (1.0 - mask) * A
-
-        return A
-
     @staticmethod
-    def _get_vpot_q(q, T0):
-        """
-        Internal method to calculate the electrostatic potential.
-
-        Parameters
-        ----------
-
-        q: torch.tensor (max_mm_atoms,)
-            MM point charges, padded to max_mm_atoms with zeros.
-
-        T0: torch.tensor (N_ATOMS, max_mm_atoms)
-            T0 tensor for QM atoms over MM atom positions.
-
-        Returns
-        -------
-
-        result: torch.tensor (max_mm_atoms)
-            Electrostatic potential over MM atoms.
-        """
-        return _torch.sum(T0 * q[:, None], axis=0)
-
-    @staticmethod
-    def _get_vpot_mu(mu, T1):
-        """
-        Internal method to calculate the electrostatic potential generated
-        by atomic dipoles.
-
-        Parameters
-        ----------
-
-        mu: torch.tensor (N_ATOMS, 3)
-            Atomic dipoles.
-
-        T1: torch.tensor (N_ATOMS, max_mm_atoms, 3)
-            T1 tensor for QM atoms over MM atom positions.
-
-        Returns
-        -------
-
-        result: torch.tensor (max_mm_atoms)
-            Electrostatic potential over MM atoms.
-        """
-        return -_torch.tensordot(T1, mu, ((0, 2), (0, 1)))
-
-    @classmethod
-    def _get_r_data(cls, xyz, device):
-        """
-        Internal method to calculate r_data object.
-
-        Parameters
-        ----------
-
-        xyz: torch.tensor (N_ATOMS, 3)
-            Atomic positions.
-
-        device: torch.device
-            The PyTorch device to use.
-
-        Returns
-        -------
-
-        result: r_data object
-        """
-        n_atoms = len(xyz)
-
-        rr_mat = xyz[:, None, :] - xyz[None, :, :]
-        r_mat = _torch.cdist(xyz, xyz)
-        r_inv = _torch.where(r_mat == 0.0, 0.0, 1.0 / r_mat)
-
-        r_inv1 = r_inv.repeat_interleave(3, dim=1)
-        r_inv2 = r_inv1.repeat_interleave(3, dim=0)
-
-        # Get a stacked matrix of outer products over the rr_mat tensors.
-        outer = _torch.einsum("bik,bij->bjik", rr_mat, rr_mat).reshape(
-            (n_atoms * 3, n_atoms * 3)
-        )
-
-        id2 = _torch.tile(
-            _torch.tile(
-                _torch.eye(3, dtype=_torch.float32, device=device).T, (1, n_atoms)
-            ).T,
-            (1, n_atoms),
-        )
-
-        t01 = r_inv
-        t11 = -rr_mat.reshape(n_atoms, n_atoms * 3) * r_inv1**3
-        t21 = -id2 * r_inv2**3
-        t22 = 3 * outer * r_inv2**5
-
-        return {"r_mat": r_mat, "T01": t01, "T11": t11, "T21": t21, "T22": t22}
-
-    @classmethod
-    def _get_mesh_data(cls, xyz, xyz_mesh, s):
-        """
-        Internal method, calculates mesh_data object.
-
-        Parameters
-        ----------
-
-        xyz: torch.tensor (N_ATOMS, 3)
-            Atomic positions.
-
-        xyz_mesh: torch.tensor (max_mm_atoms, 3)
-            MM positions.
-
-        s: torch.tensor (N_ATOMS,)
-            MBIS valence widths.
-        """
-        rr = xyz_mesh[None, :, :] - xyz[:, None, :]
-        r = _torch.linalg.norm(rr, axis=2)
-
-        return {
-            "T0_mesh": 1.0 / r,
-            "T0_mesh_slater": cls._get_T0_slater(r, s[:, None]),
-            "T1_mesh": -rr / r[:, :, None] ** 3,
-        }
-
-    @classmethod
-    def _get_f1_slater(cls, r, s):
-        """
-        Internal method, calculates damping factors for Slater densities.
-
-        Parameters
-        ----------
-
-        r: torch.tensor (N_ATOMS, max_mm_atoms)
-            Distances from QM to MM atoms.
-
-        s: torch.tensor (N_ATOMS,)
-            MBIS valence widths.
-
-        Returns
-        -------
-
-        result: torch.tensor (N_ATOMS, max_mm_atoms)
-        """
-        return (
-            cls._get_T0_slater(r, s) * r
-            - _torch.exp(-r / s) / s * (0.5 + r / (s * 2)) * r
-        )
-
-    @staticmethod
-    def _get_T0_slater(r, s):
-        """
-        Internal method, calculates T0 tensor for Slater densities.
-
-        Parameters
-        ----------
-
-        r: torch.tensor (N_ATOMS, max_mm_atoms)
-            Distances from QM to MM atoms.
-
-        s: torch.tensor (N_ATOMS,)
-            MBIS valence widths.
-
-        Returns
-        -------
-
-        results: torch.tensor (N_ATOMS, max_mm_atoms)
-        """
-        return (1 - (1 + r / (s * 2)) * _torch.exp(-r / s)) / r
-
-    @staticmethod
-    def _get_T0_gaussian(t01, r, s_mat):
-        """
-        Internal method, calculates T0 tensor for Gaussian densities (for QEq).
-
-        Parameters
-        ----------
-
-        t01: torch.tensor (N_ATOMS, N_ATOMS)
-            T0 tensor for QM atoms.
-
-        r: torch.tensor (N_ATOMS, N_ATOMS)
-            Distance matrix for QM atoms.
-
-        s_mat: torch.tensor (N_ATOMS, N_ATOMS)
-            Matrix of Gaussian sigmas for QM atoms.
-
-        Returns
-        -------
-
-        results: torch.tensor (N_ATOMS, N_ATOMS)
-        """
-        return t01 * _torch.erf(r / (s_mat * _np.sqrt(2)))
-
-    @classmethod
-    def _get_T2_thole(cls, tr21, tr22, au3):
-        """
-        Internal method, calculates T2 tensor with Thole damping.
-
-        Parameters
-        ----------
-
-        tr21: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-            r_data["T21"]
-
-        tr21: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-            r_data["T22"]
-
-        au3: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-            Scaled distance matrix (see _get_A_thole).
-
-        Returns
-        -------
-
-        result: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-        """
-        return cls._lambda3(au3) * tr21 + cls._lambda5(au3) * tr22
-
-    @staticmethod
-    def _lambda3(au3):
-        """
-        Internal method, calculates r^3 component of T2 tensor with Thole
-        damping.
-
-        Parameters
-        ----------
-
-        au3: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-            Scaled distance matrix (see _get_A_thole).
-
-        Returns
-        -------
-
-        result: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-        """
-        return 1 - _torch.exp(-au3)
-
-    @staticmethod
-    def _lambda5(au3):
-        """
-        Internal method, calculates r^5 component of T2 tensor with Thole
-        damping.
-
-        Parameters
-        ----------
-
-        au3: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-            Scaled distance matrix (see _get_A_thole).
-
-        Returns
-        -------
-
-        result: torch.tensor (N_ATOMS * 3, N_ATOMS * 3)
-        """
-        return 1 - (1 + au3) * _torch.exp(-au3)
-
-    @staticmethod
-    def parse_orca_input(orca_input):
+    def _parse_orca_input(orca_input):
         """
         Internal method to parse an ORCA input file.
 
@@ -2856,9 +2136,6 @@ class EMLECalculator:
 
             # Flag that NNPOps is active.
             self._nnpops_active = True
-
-            # Apply the optimised AEV symmetry functions.
-            self._aev_computer = self._torchani_model.aev_computer
 
         # Compute the energy and gradient.
         energy = self._torchani_model((atomic_numbers, coords)).energies

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -942,6 +942,7 @@ class EMLECalculator:
         self._species = self._emle._species
         self._method = self._emle._method
         self._alpha_mode = self._emle._alpha_mode
+        self._atomic_numbers = self._emle._atomic_numbers
 
         if isinstance(atomic_numbers, _np.ndarray):
             atomic_numbers = atomic_numbers.tolist()
@@ -1754,7 +1755,12 @@ class EMLECalculator:
             # Create the model.
             ani2x_emle = _ANI2xEMLE(
                 emle_model=self._model,
+                emle_species=self._species,
+                alpha_mode=self._alpha_mode,
+                mm_charges=self._mm_charges,
+                model_index=self._ani2x_model_index,
                 ani2x_model=self._torchani_model,
+                atomic_numbers=atomic_numbers,
                 device=self._device,
             )
 

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -93,6 +93,7 @@ class EMLECalculator:
         species=None,
         method="electrostatic",
         alpha_mode="species",
+        atomic_numbers=None,
         backend="torchani",
         external_backend=None,
         plugin_path=".",
@@ -157,6 +158,12 @@ class EMLECalculator:
                 "reference":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
+
+        atomic_numbers: List[int], Tuple[int], numpy.ndarray
+            Atomic numbers for the QM region. This allows use of optimised AEV
+            symmetry functions from the NNPOps package. Only use this option if
+            you are using a fixed QM region, i.e. the same QM region for each
+            call to the calculator.
 
         external_backend: str
             The name of an external backend to use to compute in vacuo energies.
@@ -411,6 +418,8 @@ class EMLECalculator:
         self._emle = _EMLE(
             model=model,
             method=method,
+            alpha_mode=alpha_mode,
+            atomic_numbers=atomic_numbers,
             mm_charges=self._mm_charges,
             device=self._device,
         )
@@ -786,6 +795,7 @@ class EMLECalculator:
             self._emle_mm = _EMLE(
                 model=model,
                 alpha_mode=alpha_mode,
+                atomic_numbers=atomic_numbers,
                 method="mm",
                 mm_charges=self._mm_charges,
                 device=self._device,
@@ -933,12 +943,16 @@ class EMLECalculator:
         self._method = self._emle._method
         self._alpha_mode = self._emle._alpha_mode
 
+        if isinstance(atomic_numbers, _np.ndarray):
+            atomic_numbers = atomic_numbers.tolist()
+
         # Store the settings as a dictionary.
         self._settings = {
             "model": None if model is None else self._model,
             "species": None if species is None else self._species,
             "method": self._method,
             "alpha_mode": self._alpha_mode,
+            "atomic_numbers": None if atomic_numbers is None else atomic_numbers,
             "backend": self._backend,
             "external_backend": None if external_backend is None else external_backend,
             "mm_charges": None if mm_charges is None else self._mm_charges.tolist(),

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -39,8 +39,6 @@ import sys as _sys
 import tempfile as _tempfile
 import yaml as _yaml
 
-import scipy.io as _scipy_io
-
 import ase as _ase
 import ase.io as _ase_io
 

--- a/emle/models/_ani.py
+++ b/emle/models/_ani.py
@@ -56,8 +56,10 @@ class ANI2xEMLE(_torch.nn.Module):
     def __init__(
         self,
         emle_model=None,
+        emle_method="electrostatic",
         emle_species=None,
         alpha_mode="species",
+        mm_charges=None,
         model_index=None,
         ani2x_model=None,
         atomic_numbers=None,
@@ -74,6 +76,19 @@ class ANI2xEMLE(_torch.nn.Module):
             Path to a custom EMLE model parameter file. If None, then the
             default model for the specified 'alpha_mode' will be used.
 
+        emle_method: str
+            The desired embedding method. Options are:
+                "electrostatic":
+                    Full ML electrostatic embedding.
+                "mechanical":
+                    ML predicted charges for the core, but zero valence charge.
+                "nonpol":
+                    Non-polarisable ML embedding. Here the induced component of
+                    the potential is zeroed.
+                "mm":
+                    MM charges are used for the core charge and valence charges
+                    are set to zero.
+
         emle_species: List[int]
             List of species (atomic numbers) supported by the EMLE model. If
             None, then the default species list will be used.
@@ -85,6 +100,10 @@ class ANI2xEMLE(_torch.nn.Module):
                 "reference":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
+
+        mm_charges: numpy.ndarray
+            An array of MM charges for atoms in the QM region in units of mod
+            electron charge. This is required if the 'mm' emle_method is specified.
 
         model_index: int
             The index of the ANI2x model to use. If None, then the full 8 model
@@ -143,8 +162,10 @@ class ANI2xEMLE(_torch.nn.Module):
         # Create an instance of the EMLE model.
         self._emle = _EMLE(
             model=emle_model,
+            method=emle_method,
             species=emle_species,
             alpha_mode=alpha_mode,
+            mm_charges=mm_charges,
             device=device,
             dtype=dtype,
             create_aev_calculator=False,

--- a/emle/models/_ani.py
+++ b/emle/models/_ani.py
@@ -27,6 +27,7 @@ __email__ = "lester.hedges@gmail.com"
 
 __all__ = ["ANI2xEMLE"]
 
+import numpy as _np
 import torch as _torch
 import torchani as _torchani
 
@@ -89,7 +90,7 @@ class ANI2xEMLE(_torch.nn.Module):
                     MM charges are used for the core charge and valence charges
                     are set to zero.
 
-        emle_species: List[int]
+        emle_species: List[int], Tuple[int], numpy.ndarray, torch.Tensor
             List of species (atomic numbers) supported by the EMLE model. If
             None, then the default species list will be used.
 
@@ -101,9 +102,9 @@ class ANI2xEMLE(_torch.nn.Module):
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
 
-        mm_charges: numpy.ndarray
-            An array of MM charges for atoms in the QM region in units of mod
-            electron charge. This is required if the 'mm' emle_method is specified.
+        mm_charges: List[float], Tuple[Float], numpy.ndarray, torch.Tensor
+            List of MM charges for atoms in the QM region in units of mod
+            electron charge. This is required if the 'mm' method is specified.
 
         model_index: int
             The index of the ANI2x model to use. If None, then the full 8 model
@@ -115,10 +116,11 @@ class ANI2xEMLE(_torch.nn.Module):
             the ANI2x model from which it derived was created using
             periodic_table_index=True.
 
-        atomic_numbers: torch.Tensor (N_ATOMS,)
-            List of atomic numbers to use in the ANI2x model. If specified,
-            and NNPOps is available, then an optimised version of ANI2x will
-            be used.
+        atomic_numbers: List[float], Tuple[float], numpy.ndarray, torch.Tensor (N_ATOMS,)
+            Atomic numbers for the QM region. This allows use of optimised AEV
+            symmetry functions from the NNPOps package. Only use this option
+            if you are using a fixed QM region, i.e. the same QM region for each
+            evalulation of the module.
 
         device: torch.device
             The device on which to run the model.
@@ -150,6 +152,13 @@ class ANI2xEMLE(_torch.nn.Module):
             dtype = _torch.get_default_dtype()
 
         if atomic_numbers is not None:
+            if isinstance(atomic_numbers, _np.ndarray):
+                atomic_numbers = atomic_numbers.tolist()
+            if isinstance(atomic_numbers, (list, tuple)):
+                if not all(isinstance(i, int) for i in atomic_numbers):
+                    raise ValueError("'atomic_numbers' must be a list of integers")
+                else:
+                    atomic_numbers = _torch.tensor(atomic_numbers, dtype=_torch.int64)
             if not isinstance(atomic_numbers, _torch.Tensor):
                 raise TypeError("'atomic_numbers' must be of type 'torch.Tensor'")
             # Check that they are integers.
@@ -165,6 +174,7 @@ class ANI2xEMLE(_torch.nn.Module):
             method=emle_method,
             species=emle_species,
             alpha_mode=alpha_mode,
+            atomic_numbers=(atomic_numbers if atomic_numbers is not None else None),
             mm_charges=mm_charges,
             device=device,
             dtype=dtype,
@@ -212,10 +222,10 @@ class ANI2xEMLE(_torch.nn.Module):
             # Optimise the ANI2x model if atomic_numbers are specified.
             if atomic_numbers is not None:
                 try:
-                    species = atomic_numbers.reshape(1, *atomic_numbers.shape)
-                    self._ani2x = _NNPOps.OptimizedTorchANI(self._ani2x, species).to(
-                        device
-                    )
+                    atomic_numbers = atomic_numbers.reshape(1, *atomic_numbers.shape)
+                    self._ani2x = _NNPOps.OptimizedTorchANI(
+                        self._ani2x, atomic_numbers
+                    ).to(device)
                 except:
                     pass
 

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -241,6 +241,8 @@ class EMLE(_torch.nn.Module):
                     raise ValueError(
                         "All elements of 'species' must be greater than zero"
                     )
+                # Use the custom species.
+                self._species = species
             else:
                 # Use the default species.
                 species = self._species

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -84,8 +84,10 @@ class EMLE(_torch.nn.Module):
     def __init__(
         self,
         model=None,
+        method="electrostatic",
         species=None,
         alpha_mode="species",
+        mm_charges=None,
         device=None,
         dtype=None,
         create_aev_calculator=True,
@@ -100,6 +102,21 @@ class EMLE(_torch.nn.Module):
             Path to a custom EMLE model parameter file. If None, then the
             default model for the specified 'alpha_mode' will be used.
 
+        method: str
+            The desired embedding method. Options are:
+                "electrostatic":
+                    Full ML electrostatic embedding.
+                "mechanical":
+                    ML predicted charges for the core, but zero valence charge.
+                "nonpol":
+                    Non-polarisable ML embedding. Here the induced component of
+                    the potential is zeroed.
+                "mm":
+                    MM charges are used for the core charge and valence charges
+                    are set to zero. If this option is specified then the user
+                    should also specify the MM charges for atoms in the QM
+                    region.
+
         species: List[int]
             List of species (atomic numbers) supported by the EMLE model. If
             None, then the default species list will be used.
@@ -111,6 +128,10 @@ class EMLE(_torch.nn.Module):
                 "reference":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
+
+        mm_charges: numpy.ndarray
+            An array of MM charges for atoms in the QM region in units of mod
+            electron charge. This is required if the 'mm' method is specified.
 
         device: torch.device
             The device on which to run the model.
@@ -133,13 +154,31 @@ class EMLE(_torch.nn.Module):
         # Fetch or update the resources.
         _fetch_resources()
 
+        if not isinstance(method, str):
+            raise TypeError("'method' must be of type 'str'")
+        method = method.lower().replace(" ", "")
+        if method not in ["electrostatic", "mechanical", "nonpol", "mm"]:
+            raise ValueError(
+                "'method' must be 'electrostatic', 'mechanical', 'nonpol', or 'mm'"
+            )
+        self._method = method
+
         if not isinstance(alpha_mode, str):
             raise TypeError("'alpha_mode' must be of type 'str'")
-        # Convert to lower case and strip whitespace.
         alpha_mode = alpha_mode.lower().replace(" ", "")
         if alpha_mode not in ["species", "reference"]:
             raise ValueError("'alpha_mode' must be 'species' or 'reference'")
         self._alpha_mode = alpha_mode
+
+        if method == "mm":
+            if mm_charges is None:
+                raise ValueError("MM charges must be provided for the 'mm' method")
+            if not isinstance(mm_charges, _np.ndarray):
+                raise TypeError("'mm_charges' must be of type 'numpy.ndarray'")
+            if mm_charges.dtype != _np.float64:
+                raise ValueError("'mm_charges' must be of type 'numpy.float64'")
+            if mm_charges.ndim != 1:
+                raise ValueError("'mm_charges' must be a 1D array")
 
         if model is not None:
             if not isinstance(model, str):
@@ -215,6 +254,10 @@ class EMLE(_torch.nn.Module):
         # Store model parameters as tensors.
         aev_mask = _torch.tensor(params["aev_mask"], dtype=_torch.bool, device=device)
         q_core = _torch.tensor(params["q_core"], dtype=dtype, device=device)
+        if method == "mm":
+            q_core_mm = _torch.tensor(mm_charges, dtype=dtype, device=device)
+        else:
+            q_core_mm = _torch.empty(0, dtype=dtype, device=device)
         a_QEq = _torch.tensor(params["a_QEq"], dtype=dtype, device=device)
         a_Thole = _torch.tensor(params["a_Thole"], dtype=dtype, device=device)
         if self._alpha_mode == "species":
@@ -279,6 +322,7 @@ class EMLE(_torch.nn.Module):
         self.register_buffer("_species_map", species_map)
         self.register_buffer("_aev_mask", aev_mask)
         self.register_buffer("_q_core", q_core)
+        self.register_buffer("_q_core_mm", q_core_mm)
         self.register_buffer("_a_QEq", a_QEq)
         self.register_buffer("_a_Thole", a_Thole)
         self.register_buffer("_k", k)
@@ -306,6 +350,7 @@ class EMLE(_torch.nn.Module):
         self._species_map = self._species_map.to(*args, **kwargs)
         self._aev_mask = self._aev_mask.to(*args, **kwargs)
         self._q_core = self._q_core.to(*args, **kwargs)
+        self._q_core_mm = self._q_core_mm.to(*args, **kwargs)
         self._a_QEq = self._a_QEq.to(*args, **kwargs)
         self._a_Thole = self._a_Thole.to(*args, **kwargs)
         self._k = self._k.to(*args, **kwargs)
@@ -338,6 +383,7 @@ class EMLE(_torch.nn.Module):
         self._species_map = self._species_map.cuda(**kwargs)
         self._aev_mask = self._aev_mask.cuda(**kwargs)
         self._q_core = self._q_core.cuda(**kwargs)
+        self._q_core_mm = self._q_core_mm.cuda(**kwargs)
         self._a_QEq = self._a_QEq.cuda(**kwargs)
         self._a_Thole = self._a_Thole.cuda(**kwargs)
         self._k = self._k.cuda(**kwargs)
@@ -367,6 +413,7 @@ class EMLE(_torch.nn.Module):
         self._species_map = self._species_map.cpu(**kwargs)
         self._aev_mask = self._aev_mask.cpu(**kwargs)
         self._q_core = self._q_core.cpu(**kwargs)
+        self._q_core_mm = self._q_core_mm.cpu(**kwargs)
         self._a_QEq = self._a_QEq.cpu(**kwargs)
         self._a_Thole = self._a_Thole.cpu(**kwargs)
         self._k = self._k.cpu(**kwargs)
@@ -394,6 +441,7 @@ class EMLE(_torch.nn.Module):
         if self._aev_computer is not None:
             self._aev_computer = self._aev_computer.double()
         self._q_core = self._q_core.double()
+        self._q_core_mm = self._q_core_mm.double()
         self._a_QEq = self._a_QEq.double()
         self._a_Thole = self._a_Thole.double()
         self._k = self._k.double()
@@ -416,6 +464,7 @@ class EMLE(_torch.nn.Module):
         if self._aev_computer is not None:
             self._aev_computer = self._aev_computer.float()
         self._q_core = self._q_core.float()
+        self._q_core_mm = self._q_core_mm.float()
         self._a_QEq = self._a_QEq.float()
         self._a_Thole = self._a_Thole.float()
         self._k = self._k.float()
@@ -490,24 +539,40 @@ class EMLE(_torch.nn.Module):
         xyz_mm_bohr = xyz_mm * ANGSTROM_TO_BOHR
 
         # Compute the static energy.
-        q_core = self._q_core[species_id]
+        if self._method != "mm":
+            q_core = self._q_core[species_id]
+        else:
+            q_core = self._q_core_mm
         if self._alpha_mode == "species":
             k = self._k[species_id]
         else:
             k = self._gpr(aev, self._ref_mean_k, self._c_k, species_id) ** 2
         r_data = self._get_r_data(xyz_qm_bohr)
         mesh_data = self._get_mesh_data(xyz_qm_bohr, xyz_mm_bohr, s)
-        q = self._get_q(r_data, s, chi)
-        q_val = q - q_core
-        mu_ind = self._get_mu_ind(r_data, mesh_data, charges_mm, s, q_val, k)
+        if self._method in ["electrostatic", "nonpol"]:
+            q = self._get_q(r_data, s, chi)
+            q_val = q - q_core
+        elif self._method == "mechanical":
+            q_core = self._get_q(r_data, s, chi)
+            q_val = _torch.zeros_like(
+                q_core, dtype=charges_mm.dtype, device=self._device
+            )
+        else:
+            q_val = _torch.zeros_like(
+                q_core, dtype=charges_mm.dtype, device=self._device
+            )
         vpot_q_core = self._get_vpot_q(q_core, mesh_data[0])
         vpot_q_val = self._get_vpot_q(q_val, mesh_data[1])
         vpot_static = vpot_q_core + vpot_q_val
         E_static = _torch.sum(vpot_static @ charges_mm)
 
         # Compute the induced energy.
-        vpot_ind = self._get_vpot_mu(mu_ind, mesh_data[2])
-        E_ind = _torch.sum(vpot_ind @ charges_mm) * 0.5
+        if self._method == "electrostatic":
+            mu_ind = self._get_mu_ind(r_data, mesh_data, charges_mm, s, q_val, k)
+            vpot_ind = self._get_vpot_mu(mu_ind, mesh_data[2])
+            E_ind = _torch.sum(vpot_ind @ charges_mm) * 0.5
+        else:
+            E_ind = _torch.tensor(0.0, dtype=charges_mm.dtype, device=self._device)
 
         return _torch.stack([E_static, E_ind])
 

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -341,6 +341,17 @@ class EMLE(_torch.nn.Module):
         # Initalise an empty AEV tensor to use to store the AEVs in derived classes.
         self._aev = _torch.empty(0, dtype=dtype, device=device)
 
+    def _to_dict(self):
+        """
+        Return the configuration of the module as a dictionary.
+        """
+        return {
+            "model": self._model,
+            "method": self._method,
+            "species": self._species_map.tolist(),
+            "alpha_mode": self._alpha_mode,
+        }
+
     def to(self, *args, **kwargs):
         """
         Performs Tensor dtype and/or device conversion on the model.

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -154,6 +154,8 @@ class EMLE(_torch.nn.Module):
         # Fetch or update the resources.
         _fetch_resources()
 
+        if method is None:
+            method = "electrostatic"
         if not isinstance(method, str):
             raise TypeError("'method' must be of type 'str'")
         method = method.lower().replace(" ", "")
@@ -163,6 +165,8 @@ class EMLE(_torch.nn.Module):
             )
         self._method = method
 
+        if alpha_mode is None:
+            alpha_mode = "species"
         if not isinstance(alpha_mode, str):
             raise TypeError("'alpha_mode' must be of type 'str'")
         alpha_mode = alpha_mode.lower().replace(" ", "")
@@ -209,6 +213,9 @@ class EMLE(_torch.nn.Module):
                 # Use the default species.
                 species = self._species
         else:
+            # Set to None as this will be used in any calculator configuration.
+            self._model = None
+
             # Choose the model based on the alpha_mode.
             model = self._default_models[alpha_mode]
 

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -196,6 +196,7 @@ class EMLE(_torch.nn.Module):
                 raise ValueError(
                     "All elements of 'atomic_numbers' must be greater than zero"
                 )
+        self._atomic_numbers = atomic_numbers
 
         if method == "mm":
             if mm_charges is None:

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -63,8 +63,10 @@ class MACEEMLE(_torch.nn.Module):
     def __init__(
         self,
         emle_model=None,
+        emle_method="electrostatic",
         emle_species=None,
         alpha_mode="species",
+        mm_charges=None,
         mace_model=None,
         atomic_numbers=None,
         device=None,
@@ -80,6 +82,19 @@ class MACEEMLE(_torch.nn.Module):
             Path to a custom EMLE model parameter file. If None, then the
             default model for the specified 'alpha_mode' will be used.
 
+        emle_method: str
+            The desired embedding method. Options are:
+                "electrostatic":
+                    Full ML electrostatic embedding.
+                "mechanical":
+                    ML predicted charges for the core, but zero valence charge.
+                "nonpol":
+                    Non-polarisable ML embedding. Here the induced component of
+                    the potential is zeroed.
+                "mm":
+                    MM charges are used for the core charge and valence charges
+                    are set to zero.
+
         emle_species: List[int]
             List of species (atomic numbers) supported by the EMLE model. If
             None, then the default species list will be used.
@@ -91,6 +106,10 @@ class MACEEMLE(_torch.nn.Module):
                 "reference":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environmentw
+
+        mm_charges: numpy.ndarray
+            An array of MM charges for atoms in the QM region in units of mod
+            electron charge. This is required if the 'mm' emle_method is specified.
 
         mace_model: str
             Name of the MACE-OFF23 models to use.
@@ -135,8 +154,10 @@ class MACEEMLE(_torch.nn.Module):
         # Create an instance of the EMLE model.
         self._emle = _EMLE(
             model=emle_model,
+            method=emle_method,
             species=emle_species,
             alpha_mode=alpha_mode,
+            mm_charges=mm_charges,
             device=device,
             dtype=dtype,
             create_aev_calculator=True,

--- a/environment_sire.yaml
+++ b/environment_sire.yaml
@@ -2,7 +2,7 @@ name: emle-sire
 
 channels:
   - conda-forge
-  - openbiosim/label/emle
+  - openbiosim/label/dev
 
 dependencies:
   - ambertools


### PR DESCRIPTION
This PR refactors the `EMLECalculator` class to use the new `EMLE` Torch module internally, rather than duplicating the functionality. This will make maintenance easier going forward since all core model development will take place in `emle.models.EMLE`.

I've performed single point calculations with the calculator before and after the change and get the identical results for energies and gradients. Unit tests pass locally and via the CI. I've just not tested all backends and options exhaustively. (Hard to test via CI, since not everything is available.)