### PR TITLE
Remove redundant attributes and kwargs now that the species are encoded in future models

### DIFF
--- a/bin/emle-server
+++ b/bin/emle-server
@@ -58,10 +58,6 @@ try:
 except:
     port = None
 model = os.getenv("EMLE_MODEL")
-try:
-    species = [int(x) for x in os.getenv("EMLE_SPECIES").split(",")]
-except:
-    species = None
 method = os.getenv("EMLE_METHOD")
 alpha_mode = os.getenv("EMLE_ALPHA_MODE")
 atomic_numbers = os.getenv("EMLE_ATOMIC_NUMBERS")
@@ -134,7 +130,6 @@ env = {
     "host": host,
     "port": port,
     "model": model,
-    "species": species,
     "method": method,
     "alpha_mode": alpha_mode,
     "atomic_numbers": atomic_numbers,
@@ -190,13 +185,6 @@ parser.add_argument("--host", type=str, help="the hostname", required=False)
 parser.add_argument("--port", type=str, help="the port number", required=False)
 parser.add_argument(
     "--model", type=str, help="path to an EMLE model file", required=False
-)
-parser.add_argument(
-    "--species",
-    type=str,
-    nargs="*",
-    help="the species supported by the model",
-    required=False,
 )
 parser.add_argument(
     "--method",

--- a/emle/_utils.py
+++ b/emle/_utils.py
@@ -31,6 +31,7 @@ def _fetch_resources():
 
     import os as _os
     import pygit2 as _pygit2
+    import sys
 
     # Create the name for the expected resources directory.
     resource_dir = _os.path.join(
@@ -40,7 +41,7 @@ def _fetch_resources():
     # Check if the resources directory exists.
     if not _os.path.exists(resource_dir):
         # If it doesn't, clone the resources repository.
-        print("Downloading EMLE resources...")
+        print("Downloading EMLE resources...", file=sys.stderr)
         _pygit2.clone_repository(
             "https://github.com/chemle/emle-models.git", resource_dir
         )

--- a/emle/models/_ani.py
+++ b/emle/models/_ani.py
@@ -58,7 +58,6 @@ class ANI2xEMLE(_torch.nn.Module):
         self,
         emle_model=None,
         emle_method="electrostatic",
-        emle_species=None,
         alpha_mode="species",
         mm_charges=None,
         model_index=None,
@@ -89,10 +88,6 @@ class ANI2xEMLE(_torch.nn.Module):
                 "mm":
                     MM charges are used for the core charge and valence charges
                     are set to zero.
-
-        emle_species: List[int], Tuple[int], numpy.ndarray, torch.Tensor
-            List of species (atomic numbers) supported by the EMLE model. If
-            None, then the default species list will be used.
 
         alpha_mode: str
             How atomic polarizabilities are calculated.
@@ -173,7 +168,6 @@ class ANI2xEMLE(_torch.nn.Module):
         self._emle = _EMLE(
             model=emle_model,
             method=emle_method,
-            species=emle_species,
             alpha_mode=alpha_mode,
             atomic_numbers=(atomic_numbers if atomic_numbers is not None else None),
             mm_charges=mm_charges,

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -83,7 +83,6 @@ class EMLE(_torch.nn.Module):
         self,
         model=None,
         method="electrostatic",
-        species=None,
         alpha_mode="species",
         atomic_numbers=None,
         mm_charges=None,
@@ -115,10 +114,6 @@ class EMLE(_torch.nn.Module):
                     are set to zero. If this option is specified then the user
                     should also specify the MM charges for atoms in the QM
                     region.
-
-        species: List[int], Tuple[int], numpy.ndarray, torch.Tensor
-            List of species (atomic numbers) supported by the EMLE model. If
-            None, then the default species list will be used.
 
         alpha_mode: str
             How atomic polarizabilities are calculated.
@@ -220,26 +215,6 @@ class EMLE(_torch.nn.Module):
             if not _os.path.isfile(abs_model):
                 raise IOError(f"Unable to locate EMLE embedding model file: '{model}'")
             self._model = abs_model
-
-            # Validate the species for the custom model.
-            if species is not None:
-                if isinstance(species, (_np.ndarray, _torch.Tensor)):
-                    species = species.tolist()
-                if not isinstance(species, (tuple, list)):
-                    raise TypeError(
-                        "'species' must be of type 'list', 'tuple', or 'numpy.ndarray'"
-                    )
-                if not all(isinstance(s, int) for s in species):
-                    raise TypeError("All elements of 'species' must be of type 'int'")
-                if not all(s > 0 for s in species):
-                    raise ValueError(
-                        "All elements of 'species' must be greater than zero"
-                    )
-                # Use the custom species.
-                self._species = species
-            else:
-                # Use the default species.
-                species = self._species
         else:
             # Set to None as this will be used in any calculator configuration.
             self._model = None

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -173,7 +173,8 @@ class EMLEBase(_torch.nn.Module):
                 )
             if not isinstance(aev_computer, tuple(allowed_types)):
                 raise TypeError(
-                    "'aev_computer' must be of type 'torchani.AEVComputer' or 'NNPOps.SymmetryFunctions.TorchANISymmetryFunctions'"
+                    "'aev_computer' must be of type 'torchani.AEVComputer' or "
+                    "'NNPOps.SymmetryFunctions.TorchANISymmetryFunctions'"
                 )
             self._aev_computer = aev_computer
         else:

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -64,7 +64,6 @@ class MACEEMLE(_torch.nn.Module):
         self,
         emle_model=None,
         emle_method="electrostatic",
-        emle_species=None,
         alpha_mode="species",
         mm_charges=None,
         mace_model=None,
@@ -94,10 +93,6 @@ class MACEEMLE(_torch.nn.Module):
                 "mm":
                     MM charges are used for the core charge and valence charges
                     are set to zero.
-
-        emle_species: List[int], Tuple[int], numpy.ndarray, torch.Tensor
-            List of species (atomic numbers) supported by the EMLE model. If
-            None, then the default species list will be used.
 
         alpha_mode: str
             How atomic polarizabilities are calculated.
@@ -175,7 +170,6 @@ class MACEEMLE(_torch.nn.Module):
         self._emle = _EMLE(
             model=emle_model,
             method=emle_method,
-            species=emle_species,
             alpha_mode=alpha_mode,
             atomic_numbers=(atomic_numbers if atomic_numbers is not None else None),
             mm_charges=mm_charges,


### PR DESCRIPTION
This PR removes the `species` related attributes, kwargs, and environment variables, since this is now encoded in the EMLE model itself. Users of existing custom models will need to add a `species` key to their model files.