### PR TITLE
Fix total charge

### DIFF
--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1208,7 +1208,7 @@ class EMLECalculator:
                 E_mm_qm_vac, grad_mm_qm_vac = 0.0, _np.zeros_like(xyz_qm)
 
             # Compute the embedding contributions.
-            E = self._emle_mm(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
+            E = self._emle_mm(atomic_numbers, charges_mm, xyz_qm, xyz_mm, charge)
             dE_dxyz_qm, dE_dxyz_mm = _torch.autograd.grad(E.sum(), (xyz_qm, xyz_mm))
             dE_dxyz_qm_bohr = dE_dxyz_qm.cpu().numpy() * _BOHR_TO_ANGSTROM
             dE_dxyz_mm_bohr = dE_dxyz_mm.cpu().numpy() * _BOHR_TO_ANGSTROM
@@ -1567,8 +1567,7 @@ class EMLECalculator:
 
         # Compute energy and gradients.
         try:
-            charge = 0  # TODO: add support for charged systems
-            E = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm, charge)
+            E = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
             dE_dxyz_qm, dE_dxyz_mm = _torch.autograd.grad(E.sum(), (xyz_qm, xyz_mm))
             dE_dxyz_qm_bohr = dE_dxyz_qm.cpu().numpy() * _BOHR_TO_ANGSTROM
             dE_dxyz_mm_bohr = dE_dxyz_mm.cpu().numpy() * _BOHR_TO_ANGSTROM

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -93,6 +93,7 @@ class EMLECalculator:
         method="electrostatic",
         alpha_mode="species",
         atomic_numbers=None,
+        qm_charge=0,
         backend="torchani",
         external_backend=None,
         plugin_path=".",
@@ -160,6 +161,12 @@ class EMLECalculator:
             symmetry functions from the NNPOps package. Only use this option if
             you are using a fixed QM region, i.e. the same QM region for each
             call to the calculator.
+
+        qm_charge: int
+            The charge on the QM region. This is required when using an
+            EMLECalculator instance with the OpenMM interface. When using
+            the sander interface, the QM charge will be taken from the ORCA
+            input file.
 
         external_backend: str
             The name of an external backend to use to compute in vacuo energies.
@@ -415,6 +422,15 @@ class EMLECalculator:
         else:
             self._mm_charges = None
 
+        if qm_charge is not None:
+            try:
+                qm_charge = int(qm_charge)
+            except:
+                msg = "'qm_charge' must be of type 'int'"
+                _logger.error(msg)
+                raise TypeError(msg)
+            self._qm_charge = qm_charge
+
         # Create the EMLE model instance.
         self._emle = _EMLE(
             model=model,
@@ -422,6 +438,7 @@ class EMLECalculator:
             alpha_mode=alpha_mode,
             atomic_numbers=atomic_numbers,
             mm_charges=self._mm_charges,
+            qm_charge=self._qm_charge,
             device=self._device,
         )
 
@@ -962,6 +979,7 @@ class EMLECalculator:
             "method": self._method,
             "alpha_mode": self._alpha_mode,
             "atomic_numbers": None if atomic_numbers is None else atomic_numbers,
+            "qm_charge": self._qm_charge,
             "backend": self._backend,
             "external_backend": None if external_backend is None else external_backend,
             "mm_charges": None if mm_charges is None else self._mm_charges.tolist(),
@@ -1767,6 +1785,7 @@ class EMLECalculator:
                 model_index=self._ani2x_model_index,
                 ani2x_model=self._torchani_model,
                 atomic_numbers=atomic_numbers,
+                qm_charge=self._qm_charge,
                 device=self._device,
             )
 

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1179,7 +1179,7 @@ class EMLECalculator:
 
         # Compute energy and gradients.
         try:
-            E = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
+            E = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm, charge)
             dE_dxyz_qm, dE_dxyz_mm = _torch.autograd.grad(E.sum(), (xyz_qm, xyz_mm))
             dE_dxyz_qm_bohr = dE_dxyz_qm.cpu().numpy() * _BOHR_TO_ANGSTROM
             dE_dxyz_mm_bohr = dE_dxyz_mm.cpu().numpy() * _BOHR_TO_ANGSTROM
@@ -1567,7 +1567,8 @@ class EMLECalculator:
 
         # Compute energy and gradients.
         try:
-            E = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
+            charge = 0  # TODO: add support for charged systems
+            E = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm, charge)
             dE_dxyz_qm, dE_dxyz_mm = _torch.autograd.grad(E.sum(), (xyz_qm, xyz_mm))
             dE_dxyz_qm_bohr = dE_dxyz_qm.cpu().numpy() * _BOHR_TO_ANGSTROM
             dE_dxyz_mm_bohr = dE_dxyz_mm.cpu().numpy() * _BOHR_TO_ANGSTROM
@@ -1779,6 +1780,7 @@ class EMLECalculator:
         # Compute the energy and gradients. Don't use optimised execution to
         # avoid warmup costs.
         with _torch.jit.optimized_execution(False):
+            # ANI-2x systems are always neutral, so charge not needed here
             E = self._ani2x_emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
             dE_dxyz_qm, dE_dxyz_mm = _torch.autograd.grad(
                 E.sum(), (xyz_qm, xyz_mm), allow_unused=allow_unused

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -437,8 +437,9 @@ class EMLE(_torch.nn.Module):
         # These are returned as batched tensors, so we need to extract the
         # first element of each.
         s, q_core, q_val, A_thole = self._emle_base(
-            atomic_numbers[None, :], xyz_qm[None, :, :],
-            _torch.tensor([q_total], dtype=xyz_qm.dtype, device=xyz_qm.device)
+            atomic_numbers[None, :],
+            xyz_qm[None, :, :],
+            _torch.tensor([q_total], dtype=xyz_qm.dtype, device=xyz_qm.device),
         )
 
         # Convert coordinates to Bohr.


### PR DESCRIPTION
This PR supersedes #37, implementing the fix in a way that doesn't break the API and works with both the sander and OpenMM interfaces. The user can now specify the charge of the QM region using the `qm_charge` kwarg via the constructor of an EMLE model, or via the forward method at runtime. Within the forward method the non-default value will be used, meaning that the user can set once via the constructor and leave the forward kwarg unset (OpenMM interface) or leave the constructor value unset and use the forward method kwarg at runtime (sander interface). I've also reworked the code to make it compatible with TorchScript, i.e. adding type hints to the forward methods so that it knows `qm_charge` is an `int`.