### PR TITLE
Sander imin6 fix

### DIFF
--- a/bin/orca
+++ b/bin/orca
@@ -100,6 +100,9 @@ try:
 
     if msg == "emlefin":
         print("Received notice that the EMLE calculation has finished.")
+        print("Dummy dipole for consistency with sander API when imin=6:")
+        print("Total Dipole Moment    :      0.00000       0.00000       0.00000\n")
+        print("Magnitude (a.u.)       :      0.00000")
     elif msg == "emlefail":
         print("Received notice that the EMLE calculation has failed.")
         print(f"[ERROR] {err}")

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1033,7 +1033,6 @@ class EMLECalculator:
         # Log energies to file.
         if (
             self._energy_frequency > 0
-            and not self._is_first_step
             and self._step % self._energy_frequency == 0
         ):
             with open(self._energy_file, "a+") as f:
@@ -1068,11 +1067,8 @@ class EMLECalculator:
                 f.write("\n")
 
         # Increment the step counter.
-        if self._is_first_step:
-            self._is_first_step = False
-        else:
-            self._step += 1
-            _logger.info(f"Step: {self._step}")
+        self._step += 1
+        _logger.info(f"Step: {self._step}")
 
     def _calculate_energy_and_gradients(
         self,

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1033,6 +1033,7 @@ class EMLECalculator:
         # Log energies to file.
         if (
             self._energy_frequency > 0
+            and not self._is_first_step
             and self._step % self._energy_frequency == 0
         ):
             with open(self._energy_file, "a+") as f:
@@ -1067,8 +1068,11 @@ class EMLECalculator:
                 f.write("\n")
 
         # Increment the step counter.
-        self._step += 1
-        _logger.info(f"Step: {self._step}")
+        if self._is_first_step:
+            self._is_first_step = False
+        else:
+            self._step += 1
+            _logger.info(f"Step: {self._step}")
 
     def _calculate_energy_and_gradients(
         self,


### PR DESCRIPTION
When using sander with imin=6 to do SP calculations over an existing trajectory, it expects the dipole moment to be present in the ORCA output. This PR prints dummy values to make sander happy. 