### PR TITLE
Fix typo in DeepMD class name

### DIFF
--- a/emle/_backends/_deepmd.py
+++ b/emle/_backends/_deepmd.py
@@ -22,7 +22,7 @@
 
 """DeePMD in-vacuo backend implementation."""
 
-__all__ = ["DeePMD"]
+__all__ = ["DeepMD"]
 
 import ase as _ase
 import numpy as _np
@@ -33,7 +33,7 @@ from .._units import _EV_TO_HARTREE, _BOHR_TO_ANGSTROM
 from ._backend import Backend as _Backend
 
 
-class DeePMD(_Backend):
+class DeepMD(_Backend):
     """
     DeepMD in-vacuo backend implementation.
     """

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -121,7 +121,7 @@ def test_deepmd(data):
 
     with tempfile.NamedTemporaryFile() as tmp:
         # Instantiate the DeePMD backend.
-        backend = DeePMD(models, deviation=tmp.name)
+        backend = DeepMD(models, deviation=tmp.name)
 
         # Calculate the energy and forces.
         energy, forces = backend(atomic_numbers, xyz)


### PR DESCRIPTION
Elsewhere in the code the class is imported as  `DeepMD`, so changed the class name