### PR TITLE
Fix imports for DeePMD backend

### DIFF
--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -95,9 +95,9 @@ elif args.backend == "mace":
 
     backend = MACEEMLE(mace_model=args.mace_model)
 elif args.backend == "deepmd":
-    from emle._backends import DeepMD
+    from emle._backends import DeePMD
 
-    backend = DeepMD(args.deepmd_model)
+    backend = DeePMD(args.deepmd_model)
 
 emle_base = EMLE(model=args.emle_model, alpha_mode=args.alpha_mode)._emle_base
 

--- a/emle/_backends/_deepmd.py
+++ b/emle/_backends/_deepmd.py
@@ -35,7 +35,7 @@ from ._backend import Backend as _Backend
 
 class DeePMD(_Backend):
     """
-    DeepMD in-vacuo backend implementation.
+    DeePMD in-vacuo backend implementation.
     """
 
     def __init__(self, model, deviation=None, deviation_threshold=None):

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -665,9 +665,9 @@ class EMLECalculator:
 
             elif backend == "deepmd":
                 try:
-                    from ._backends import DeepMD
+                    from ._backends import DeePMD
 
-                    b = DeepMD(
+                    b = DeePMD(
                         model=deepmd_model,
                         deviation=deepmd_deviation,
                         deviation_threshold=deepmd_deviation_threshold,


### PR DESCRIPTION
This PR closes #52 by fixing the import name for the `DeePMD` backend, which was incorrectly imported as `DeepMD`.