### PR TITLE
Add Lennard-Jones implementation and training of dispersion coefficients

### DIFF
--- a/emle/_analyzer.py
+++ b/emle/_analyzer.py
@@ -49,7 +49,7 @@ class EMLEAnalyzer:
         parser=None,
         q_total=None,
         start=None,
-        end=None
+        end=None,
     ):
         """
         Constructor.
@@ -168,7 +168,7 @@ class EMLEAnalyzer:
             self.qm_xyz,
             self.q_total,
         )
-        self.atomic_alpha = 1. / _torch.diagonal(self.A_thole, dim1=1, dim2=2)[:, ::3]
+        self.atomic_alpha = 1.0 / _torch.diagonal(self.A_thole, dim1=1, dim2=2)[:, ::3]
         self.alpha = self._get_mol_alpha(self.A_thole, self.atomic_numbers)
 
         mask = (self.atomic_numbers > 0).unsqueeze(-1)

--- a/emle/_orca_parser.py
+++ b/emle/_orca_parser.py
@@ -125,7 +125,6 @@ class ORCAParser:
 
         try:
             with _tarfile.open(filename, "r") as tar:
-
                 self._tar = tar
                 self.names = self._get_names(tar)
 

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1327,12 +1327,15 @@ class EMLECalculator:
                 _logger.error(msg)
                 raise RuntimeError(msg)
 
-            if (self._qbc_deviation):
+            if self._qbc_deviation:
                 E_std = _torch.std(base_model._E_vac_qbc).item()
                 max_f_std = _torch.max(_torch.std(base_model._grads_qbc, axis=0)).item()
                 with open(self._qbc_deviation, "a") as f:
                     f.write(f"{E_std:12.5f}{max_f_std:12.5f}\n")
-                if self._qbc_deviation_threshold and max_f_std > self._qbc_deviation_threshold:
+                if (
+                    self._qbc_deviation_threshold
+                    and max_f_std > self._qbc_deviation_threshold
+                ):
                     msg = "Force deviation threshold reached!"
                     raise ValueError(msg)
 
@@ -1371,7 +1374,7 @@ class EMLECalculator:
             else:
                 offset = int(not self._restart)
                 lam = self._lambda_interpolate[0] + (
-                    (self._step / (self._interpolate_steps - offset))
+                    self._step / (self._interpolate_steps - offset)
                 ) * (self._lambda_interpolate[1] - self._lambda_interpolate[0])
                 if lam < 0.0:
                     lam = 0.0

--- a/emle/models/_ani.py
+++ b/emle/models/_ani.py
@@ -375,7 +375,7 @@ class ANI2xEMLE(_torch.nn.Module):
         -------
 
         result: torch.Tensor (3,) or (3, BATCH)
-            The ANI2x and static and induced EMLE energy components in Hartree.
+            The ANI2x and static, induced and LJ EMLE energy components in Hartree.
         """
         # Batch the inputs if necessary.
         if atomic_numbers.ndim == 1:
@@ -407,4 +407,4 @@ class ANI2xEMLE(_torch.nn.Module):
         E_emle = self._emle(atomic_numbers, charges_mm, xyz_qm, xyz_mm, qm_charge)
 
         # Return the ANI2x and EMLE energy components.
-        return _torch.stack((E_vac, E_emle[0], E_emle[1]))
+        return _torch.stack((E_vac, E_emle[0], E_emle[1], E_emle[2]))

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -352,9 +352,9 @@ class EMLE(_torch.nn.Module):
                 if "sqrtk_ref" in params
                 else None
             ),
-            "ref_values_C6": (
-                _torch.tensor(params["ref_values_C6"], dtype=dtype, device=device)
-                if "ref_values_C6" in params
+            "ref_values_c6": (
+                _torch.tensor(params["c6_ref"], dtype=dtype, device=device)
+                if "c6_ref" in params
                 else None
             ),
         }
@@ -440,11 +440,11 @@ class EMLE(_torch.nn.Module):
 
         if lj_xyz_qm:
             # Get the LJ parameters for the passed configuration
-            _, _, _, A_thole, C6 = self._emle_base(
+            _, _, _, A_thole, c6 = self._emle_base(
                 self.atomic_numbers, lj_xyz_qm, qm_charge
             )
             alpha_qm = self._emle_base.get_isotropic_polarizabilities(A_thole)
-            sigma_qm, epsilon_qm = self._emle_base.get_lj_parameters(C6, alpha_qm)
+            sigma_qm, epsilon_qm = self._emle_base.get_lj_parameters(c6, alpha_qm)
             self._lj_sigma_qm = sigma_qm
             self._lj_epsilon_qm = epsilon_qm
 
@@ -578,7 +578,7 @@ class EMLE(_torch.nn.Module):
             )
 
         # Get the parameters from the base model.
-        s, q_core, q_val, A_thole, C6 = self._emle_base(
+        s, q_core, q_val, A_thole, c6 = self._emle_base(
             self._atomic_numbers,
             self._xyz_qm,
             qm_charge,
@@ -621,7 +621,7 @@ class EMLE(_torch.nn.Module):
         if self._lj_mode is not None:
             if self._lj_mode == "flexible":
                 alpha_qm = self._emle_base.get_isotropic_polarizabilities(A_thole)
-                sigma_qm, epsilon_qm = self._emle_base.get_lj_parameters(C6, alpha_qm)
+                sigma_qm, epsilon_qm = self._emle_base.get_lj_parameters(c6, alpha_qm)
             elif self._lj_mode == "fixed":
                 sigma_qm = self._lj_sigma_qm.expand(batch_size, -1)
                 epsilon_qm = self._lj_epsilon_qm.expand(batch_size, -1)

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -212,10 +212,10 @@ class EMLEBase(_torch.nn.Module):
         if lj_mode is not None:
             assert lj_mode in ["static", "dynamic"], "Invalid Lennard-Jones mode"
             try:
-                self.ref_values_C6 = _torch.nn.Parameter(params["ref_values_C6"])
+                self.ref_values_c6 = _torch.nn.Parameter(params["c6_ref"])
             except:
                 msg = (
-                    "Missing 'ref_values_C6' key in params. This is required when "
+                    "Missing 'c6_ref' key in params. This is required when "
                     "using the Lennard-Jones potential."
                 )
                 raise ValueError(msg)
@@ -257,10 +257,10 @@ class EMLEBase(_torch.nn.Module):
             ref_mean_sqrtk, c_sqrtk = self._get_c(n_ref, self.ref_values_sqrtk, Kinv)
 
         if lj_mode is not None:
-            ref_mean_C6, c_C6 = self._get_c(n_ref, self.ref_values_C6, Kinv)
+            ref_mean_c6, c_c6 = self._get_c(n_ref, self.ref_values_c6, Kinv)
         else:
-            ref_mean_C6 = _torch.zeros_like(ref_mean_s, dtype=dtype, device=device)
-            c_C6 = _torch.zeros_like(c_s, dtype=dtype, device=device)
+            ref_mean_c6 = _torch.zeros_like(ref_mean_s, dtype=dtype, device=device)
+            c_c6 = _torch.zeros_like(c_s, dtype=dtype, device=device)
 
         # Store the current device.
         self._device = device
@@ -274,11 +274,11 @@ class EMLEBase(_torch.nn.Module):
         self.register_buffer("_ref_mean_s", ref_mean_s)
         self.register_buffer("_ref_mean_chi", ref_mean_chi)
         self.register_buffer("_ref_mean_sqrtk", ref_mean_sqrtk)
-        self.register_buffer("_ref_mean_C6", ref_mean_C6)
+        self.register_buffer("_ref_mean_c6", ref_mean_c6)
         self.register_buffer("_c_s", c_s)
         self.register_buffer("_c_chi", c_chi)
         self.register_buffer("_c_sqrtk", c_sqrtk)
-        self.register_buffer("_c_C6", c_C6)
+        self.register_buffer("_c_c6", c_c6)
 
     def to(self, *args, **kwargs):
         """
@@ -293,11 +293,11 @@ class EMLEBase(_torch.nn.Module):
         self._ref_mean_s = self._ref_mean_s.to(*args, **kwargs)
         self._ref_mean_chi = self._ref_mean_chi.to(*args, **kwargs)
         self._ref_mean_sqrtk = self._ref_mean_sqrtk.to(*args, **kwargs)
-        self._ref_mean_C6 = self._ref_mean_C6.to(*args, **kwargs)
+        self._ref_mean_c6 = self._ref_mean_c6.to(*args, **kwargs)
         self._c_s = self._c_s.to(*args, **kwargs)
         self._c_chi = self._c_chi.to(*args, **kwargs)
         self._c_sqrtk = self._c_sqrtk.to(*args, **kwargs)
-        self._c_C6 = self._c_C6.to(*args, **kwargs)
+        self._c_c6 = self._c_c6.to(*args, **kwargs)
         self.k_Z = _torch.nn.Parameter(self.k_Z.to(*args, **kwargs))
 
         # Check for a device type in args and update the device attribute.
@@ -321,11 +321,11 @@ class EMLEBase(_torch.nn.Module):
         self._ref_mean_s = self._ref_mean_s.cuda(**kwargs)
         self._ref_mean_chi = self._ref_mean_chi.cuda(**kwargs)
         self._ref_mean_sqrtk = self._ref_mean_sqrtk.cuda(**kwargs)
-        self._ref_mean_C6 = self._ref_mean_C6.cuda(**kwargs)
+        self._ref_mean_c6 = self._ref_mean_c6.cuda(**kwargs)
         self._c_s = self._c_s.cuda(**kwargs)
         self._c_chi = self._c_chi.cuda(**kwargs)
         self._c_sqrtk = self._c_sqrtk.cuda(**kwargs)
-        self._c_C6 = self._c_C6.cuda(**kwargs)
+        self._c_c6 = self._c_c6.cuda(**kwargs)
         self.k_Z = _torch.nn.Parameter(self.k_Z.cuda(**kwargs))
 
         # Update the device attribute.
@@ -346,11 +346,11 @@ class EMLEBase(_torch.nn.Module):
         self._ref_mean_s = self._ref_mean_s.cpu(**kwargs)
         self._ref_mean_chi = self._ref_mean_chi.cpu(**kwargs)
         self._ref_mean_sqrtk = self._ref_mean_sqrtk.cpu(**kwargs)
-        self._ref_mean_C6 = self._ref_mean_C6.cpu(**kwargs)
+        self._ref_mean_c6 = self._ref_mean_c6.cpu(**kwargs)
         self._c_s = self._c_s.cpu(**kwargs)
         self._c_chi = self._c_chi.cpu(**kwargs)
         self._c_sqrtk = self._c_sqrtk.cpu(**kwargs)
-        self._c_C6 = self._c_C6.cpu(**kwargs)
+        self._c_c6 = self._c_c6.cpu(**kwargs)
         self.k_Z = _torch.nn.Parameter(self.k_Z.cpu(**kwargs))
 
         # Update the device attribute.
@@ -369,11 +369,11 @@ class EMLEBase(_torch.nn.Module):
         self._ref_mean_s = self._ref_mean_s.double()
         self._ref_mean_chi = self._ref_mean_chi.double()
         self._ref_mean_sqrtk = self._ref_mean_sqrtk.double()
-        self._ref_mean_C6 = self._ref_mean_C6.double()
+        self._ref_mean_c6 = self._ref_mean_c6.double()
         self._c_s = self._c_s.double()
         self._c_chi = self._c_chi.double()
         self._c_sqrtk = self._c_sqrtk.double()
-        self._c_C6 = self._c_C6.double()
+        self._c_c6 = self._c_c6.double()
         self.k_Z = _torch.nn.Parameter(self.k_Z.double())
         return self
 
@@ -388,11 +388,11 @@ class EMLEBase(_torch.nn.Module):
         self._ref_mean_s = self._ref_mean_s.float()
         self._ref_mean_chi = self._ref_mean_chi.float()
         self._ref_mean_sqrtk = self._ref_mean_sqrtk.float()
-        self._ref_mean_C6 = self._ref_mean_C6.float()
+        self._ref_mean_c6 = self._ref_mean_c6.float()
         self._c_s = self._c_s.float()
         self._c_chi = self._c_chi.float()
         self._c_sqrtk = self._c_sqrtk.float()
-        self._c_C6 = self._c_C6.float()
+        self._c_c6 = self._c_c6.float()
         self.k_Z = _torch.nn.Parameter(self.k_Z.float())
         return self
 
@@ -460,11 +460,11 @@ class EMLEBase(_torch.nn.Module):
         A_thole = self._get_A_thole(r_data, s, q_val, k, self.a_Thole)
 
         if self._lj_mode is not None:
-            C6 = self._gpr(aev, self._ref_mean_C6, self._c_C6, species_id)
+            c6 = self._gpr(aev, self._ref_mean_c6, self._c_c6, species_id)
         else:
-            C6 = None
+            c6 = None
 
-        return s, q_core, q_val, A_thole, C6
+        return s, q_core, q_val, A_thole, c6
 
     @classmethod
     def _get_Kinv(cls, ref_features, sigma):

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -43,6 +43,7 @@ try:
 except:
     _has_nnpops = False
 
+
 class EMLEBase(_torch.nn.Module):
     """
     Base class for the EMLE model. This is used to compute valence shell
@@ -92,9 +93,9 @@ class EMLEBase(_torch.nn.Module):
                 "reference":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
-        
+
         lj_mode: str
-            Mode for calculating the Lennard-Jones potential. 
+            Mode for calculating the Lennard-Jones potential.
             If None, the Lennard-Jones potential is not calculated.
 
         emle_aev_computer: EMLEAEVComputer
@@ -207,7 +208,7 @@ class EMLEBase(_torch.nn.Module):
                     "using 'reference' alpha mode."
                 )
                 raise ValueError(msg)
-            
+
         if lj_mode is not None:
             assert lj_mode in ["static", "dynamic"], "Invalid Lennard-Jones mode"
             try:
@@ -1077,7 +1078,6 @@ class EMLEBase(_torch.nn.Module):
         results: torch.Tensor (N_BATCH, MAX_QM_ATOMS, MAX_MM_ATOMS)
         """
         return (1 - (1 + r / (s * 2)) * _torch.exp(-r / s)) / r
-    
 
     @staticmethod
     def get_lj_energy(
@@ -1192,9 +1192,9 @@ class EMLEBase(_torch.nn.Module):
 
         c6: _torch.Tensor(N_BATCH, N_ATOMS)
             C6 coefficients per atom.
-        
+
         alpha: _torch.Tensor(N_BATCH, N_ATOMS)
-            Isotropic polarizabilities per atom. 
+            Isotropic polarizabilities per atom.
 
         Returns
         -------

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -118,7 +118,14 @@ class EMLEBase(_torch.nn.Module):
             raise TypeError("'params' must be of type 'dict'")
         if not all(
             k in params
-            for k in ["a_QEq", "a_Thole", "ref_values_s", "ref_values_chi", "k_Z", "ref_values_c6"]
+            for k in [
+                "a_QEq",
+                "a_Thole",
+                "ref_values_s",
+                "ref_values_chi",
+                "k_Z",
+                "ref_values_c6",
+            ]
         ):
             raise ValueError(
                 "'params' must contain keys 'a_QEq', 'a_Thole', 'ref_values_s', 'ref_values_chi', and 'k_Z'"

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -110,7 +110,6 @@ class EMLEBase(_torch.nn.Module):
         dtype: torch.dtype
             The data type to use for the models floating point tensors.
         """
-
         # Call the base class constructor.
         super().__init__()
 
@@ -119,7 +118,7 @@ class EMLEBase(_torch.nn.Module):
             raise TypeError("'params' must be of type 'dict'")
         if not all(
             k in params
-            for k in ["a_QEq", "a_Thole", "ref_values_s", "ref_values_chi", "k_Z"]
+            for k in ["a_QEq", "a_Thole", "ref_values_s", "ref_values_chi", "k_Z", "ref_values_c6"]
         ):
             raise ValueError(
                 "'params' must contain keys 'a_QEq', 'a_Thole', 'ref_values_s', 'ref_values_chi', and 'k_Z'"
@@ -210,12 +209,12 @@ class EMLEBase(_torch.nn.Module):
                 raise ValueError(msg)
 
         if lj_mode is not None:
-            assert lj_mode in ["static", "dynamic"], "Invalid Lennard-Jones mode"
+            assert lj_mode in ["fixed", "flexible"], "Invalid Lennard-Jones mode"
             try:
-                self.ref_values_c6 = _torch.nn.Parameter(params["c6_ref"])
+                self.ref_values_c6 = _torch.nn.Parameter(params["ref_values_c6"])
             except:
                 msg = (
-                    "Missing 'c6_ref' key in params. This is required when "
+                    "Missing 'ref_values_c6' key in params. This is required when "
                     "using the Lennard-Jones potential."
                 )
                 raise ValueError(msg)
@@ -444,7 +443,6 @@ class EMLEBase(_torch.nn.Module):
         xyz_qm_bohr = xyz_qm * ANGSTROM_TO_BOHR
 
         r_data = self._get_r_data(xyz_qm_bohr, mask)
-
         q_core = self._q_core[species_id] * mask
         q = self._get_q(r_data, s, chi, q_total, mask)
         q_val = q - q_core

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -123,7 +123,7 @@ class MACEEMLE(_torch.nn.Module):
             Available pre-trained models are 'mace-off23-small', 'mace-off23-medium', 'mace-off23-large'.
             To use a locally trained MACE model, provide the path to the model file.
             If None, the MACE-OFF23(S) model will be used by default.
-            If more than one model is provided, only the energy from the first model will be returned 
+            If more than one model is provided, only the energy from the first model will be returned
             in the forward pass, but the energy and forces from all models will be stored.
 
         atomic_numbers: List[int], Tuple[int], numpy.ndarray, torch.Tensor (N_ATOMS,)
@@ -198,16 +198,25 @@ class MACEEMLE(_torch.nn.Module):
         )
 
         if not isinstance(mace_model, (list, tuple)):
-            mace_model = [mace_model] if mace_model is None or isinstance(mace_model, str) else None
+            mace_model = (
+                [mace_model]
+                if mace_model is None or isinstance(mace_model, str)
+                else None
+            )
 
-        if mace_model is None or any(not isinstance(i, (str, type(None))) for i in mace_model):
-            raise TypeError("'mace_model' must be a list, tuple, or str, with elements of type str or None")
+        if mace_model is None or any(
+            not isinstance(i, (str, type(None))) for i in mace_model
+        ):
+            raise TypeError(
+                "'mace_model' must be a list, tuple, or str, with elements of type str or None"
+            )
 
         from mace.tools.scripts_utils import extract_config_mace_model
+
         self._mace_models = _torch.nn.ModuleList()
         for model in mace_model:
             source_model = self._load_mace_model(model, device)
-            
+
             # Extract the config from the model.
             config = extract_config_mace_model(source_model)
 
@@ -281,7 +290,7 @@ class MACEEMLE(_torch.nn.Module):
             Path to the MACE model file or the name of the pre-trained MACE model.
         device: torch.device
             Device on which to load the model.
-        
+
         Returns
         -------
         source_model: torch.nn.Module
@@ -392,9 +401,9 @@ class MACEEMLE(_torch.nn.Module):
         """
         self._emle = self._emle.to(*args, **kwargs)
         self._mace = self._mace.to(*args, **kwargs)
-        self._mace_models = _torch.nn.ModuleList([
-            model.to(*args, **kwargs) for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.to(*args, **kwargs) for model in self._mace_models]
+        )
         return self
 
     def cpu(self, **kwargs):
@@ -405,9 +414,9 @@ class MACEEMLE(_torch.nn.Module):
         self._mace = self._mace.cpu(**kwargs)
         if self._atomic_numbers is not None:
             self._atomic_numbers = self._atomic_numbers.cpu(**kwargs)
-        self._mace_models = _torch.nn.ModuleList([
-            model.cpu(**kwargs) for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.cpu(**kwargs) for model in self._mace_models]
+        )
         return self
 
     def cuda(self, **kwargs):
@@ -418,9 +427,9 @@ class MACEEMLE(_torch.nn.Module):
         self._mace = self._mace.cuda(**kwargs)
         if self._atomic_numbers is not None:
             self._atomic_numbers = self._atomic_numbers.cuda(**kwargs)
-        self._mace_models = _torch.nn.ModuleList([
-            model.cuda(**kwargs) for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.cuda(**kwargs) for model in self._mace_models]
+        )
         return self
 
     def double(self):
@@ -429,9 +438,9 @@ class MACEEMLE(_torch.nn.Module):
         """
         self._emle = self._emle.double()
         self._mace = self._mace.double()
-        self._mace_models = _torch.nn.ModuleList([
-            model.double() for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.double() for model in self._mace_models]
+        )
         return self
 
     def float(self):
@@ -440,9 +449,9 @@ class MACEEMLE(_torch.nn.Module):
         """
         self._emle = self._emle.float()
         self._mace = self._mace.float()
-        self._mace_models = _torch.nn.ModuleList([
-            model.float() for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.float() for model in self._mace_models]
+        )
         return self
 
     def forward(
@@ -478,7 +487,7 @@ class MACEEMLE(_torch.nn.Module):
         -------
 
         result: torch.Tensor (3,)
-            The ANI2x and static and induced EMLE energy components in Hartree.
+            The MACE and static, induced and LJ EMLE energy components in Hartree.
         """
         # Get the device.
         device = xyz_qm.device
@@ -497,8 +506,17 @@ class MACEEMLE(_torch.nn.Module):
         num_models = len(self._mace_models)
 
         # Create tensors to store the data for QbC.
-        self._E_vac_qbc = _torch.empty(num_models, num_batches, dtype=self._dtype, device=device)
-        self._grads_qbc = _torch.empty(num_models, num_batches, xyz_qm.shape[1], 3, dtype=self._dtype, device=device)
+        self._E_vac_qbc = _torch.empty(
+            num_models, num_batches, dtype=self._dtype, device=device
+        )
+        self._grads_qbc = _torch.empty(
+            num_models,
+            num_batches,
+            xyz_qm.shape[1],
+            3,
+            dtype=self._dtype,
+            device=device,
+        )
 
         # Create tensors to store the results.
         results_E_vac = _torch.empty(num_batches, dtype=self._dtype, device=device)
@@ -550,26 +568,32 @@ class MACEEMLE(_torch.nn.Module):
 
             E_vac = self._mace(input_dict, compute_force=False)["interaction_energy"]
 
-            assert (
-                E_vac is not None
-            ), "The model did not return any energy. Please check the input."
+            assert E_vac is not None, (
+                "The model did not return any energy. Please check the input."
+            )
 
             results_E_vac[i] = E_vac[0] * EV_TO_HARTREE
 
             # Decouple the positions from the computation graph for the next models.
-            input_dict["positions"] = input_dict["positions"].clone().detach().requires_grad_(True)
+            input_dict["positions"] = (
+                input_dict["positions"].clone().detach().requires_grad_(True)
+            )
 
             # Do inference for the other models.
             if len(self._mace_models) > 1:
                 for j, mace in enumerate(self._mace_models):
-                    E_vac_qbc = mace(input_dict, compute_force=False)["interaction_energy"]
+                    E_vac_qbc = mace(input_dict, compute_force=False)[
+                        "interaction_energy"
+                    ]
 
-                    assert (
-                        E_vac_qbc is not None
-                    ), "The model did not return any energy. Please check the input."
+                    assert E_vac_qbc is not None, (
+                        "The model did not return any energy. Please check the input."
+                    )
 
                     # Calculate the gradients
-                    grads_qbc = _torch.autograd.grad([E_vac_qbc], [input_dict["positions"]])[0]
+                    grads_qbc = _torch.autograd.grad(
+                        [E_vac_qbc], [input_dict["positions"]]
+                    )[0]
                     assert grads_qbc is not None, "Gradient computation failed"
 
                     # Store the results.
@@ -582,6 +606,7 @@ class MACEEMLE(_torch.nn.Module):
                 zero = _torch.tensor(0.0, dtype=xyz_qm.dtype, device=device)
                 results_E_emle_static[i] = zero
                 results_E_emle_induced[i] = zero
+                results_E_emle_lj[i] = zero
             else:
                 # Get the EMLE energy components.
                 E_emle = self._emle(
@@ -589,8 +614,14 @@ class MACEEMLE(_torch.nn.Module):
                 )
                 results_E_emle_static[i] = E_emle[0][0]
                 results_E_emle_induced[i] = E_emle[1][0]
+                results_E_emle_lj[i] = E_emle[2][0]
 
         # Return the MACE and EMLE energy components.
         return _torch.stack(
-            [results_E_vac, results_E_emle_static, results_E_emle_induced]
+            [
+                results_E_vac,
+                results_E_emle_static,
+                results_E_emle_induced,
+                results_E_emle_lj,
+            ]
         )

--- a/emle/models/_patches.py
+++ b/emle/models/_patches.py
@@ -32,6 +32,7 @@ directly calculate energies or get an ASE calculator. For example:
     # convert atom species from string to long tensor
     model0.species_to_tensor(['C', 'H', 'H', 'H', 'H'])
 """
+
 import os
 import torch
 import torchani

--- a/emle/train/_loss.py
+++ b/emle/train/_loss.py
@@ -333,7 +333,7 @@ class DispersionCoefficientLoss(_BaseLoss):
 
         self._pol = None
 
-    def forward(self, atomic_numbers, xyz, q_mol, C6_target):
+    def forward(self, atomic_numbers, xyz, q_mol, c6_target):
         """
         Forward pass.
 
@@ -348,14 +348,14 @@ class DispersionCoefficientLoss(_BaseLoss):
         q_mol: torch.Tensor(N_BATCH, MAX_N_ATOMS)
             Molecular charges.
 
-        C6_target: torch.Tensor(N_BATCH, MAX_N_ATOMS)
+        c6_target: torch.Tensor(N_BATCH, MAX_N_ATOMS)
             Target dispersion coefficients.
         """
         # Update reference values for C6.
-        self._update_C6_gpr(self._emle_base)
+        self._update_c6_gpr(self._emle_base)
 
         # Calculate C6.
-        s, q_core, q_val, A_thole, C6 = self._emle_base(atomic_numbers, xyz, q_mol)
+        s, q_core, q_val, A_thole, c6 = self._emle_base(atomic_numbers, xyz, q_mol)
         # Calculate isotropic polarizabilities if not already calculated.
         if self._pol is None:
             self._pol = self._emle_base.calculate_isotropic_polarizabilities(
@@ -364,8 +364,8 @@ class DispersionCoefficientLoss(_BaseLoss):
 
         # Mask out dummy atoms.
         mask = atomic_numbers > 0
-        target = C6_target[mask]
-        values = C6
+        target = c6_target[mask]
+        values = c6
         values = values[mask]
 
         # Calculate loss.
@@ -378,9 +378,9 @@ class DispersionCoefficientLoss(_BaseLoss):
         )
 
     @staticmethod
-    def _update_C6_gpr(emle_base):
-        emle_base._ref_mean_C6, emle_base._c_C6 = emle_base._get_c(
+    def _update_c6_gpr(emle_base):
+        emle_base._ref_mean_c6, emle_base._c_c6 = emle_base._get_c(
             emle_base._n_ref,
-            emle_base.ref_values_C6,
+            emle_base.ref_values_c6,
             emle_base._Kinv,
         )

--- a/emle/train/_loss.py
+++ b/emle/train/_loss.py
@@ -134,7 +134,7 @@ class QEqLoss(_BaseLoss):
         self._update_chi_gpr(self._emle_base)
 
         # Calculate q_core and q_val
-        _, q_core, q_val, _ = self._emle_base(atomic_numbers, xyz, q_mol)
+        _, q_core, q_val, *_ = self._emle_base(atomic_numbers, xyz, q_mol)
 
         mask = atomic_numbers > 0
         target = q_target[mask]
@@ -275,7 +275,7 @@ class TholeLoss(_BaseLoss):
             self._update_sqrtk_gpr(self._emle_base)
 
         # Calculate A_thole and alpha_mol.
-        _, _, _, A_thole = self._emle_base(atomic_numbers, xyz, q_mol)
+        _, _, _, A_thole, *_ = self._emle_base(atomic_numbers, xyz, q_mol)
         alpha_mol = self._get_alpha_mol(A_thole, atomic_numbers > 0)
 
         triu_row, triu_col = _torch.triu_indices(3, 3, offset=0)
@@ -309,5 +309,75 @@ class TholeLoss(_BaseLoss):
         emle_base._ref_mean_sqrtk, emle_base._c_sqrtk = emle_base._get_c(
             emle_base._n_ref,
             emle_base.ref_values_sqrtk,
+            emle_base._Kinv,
+        )
+
+
+class DispersionCoefficientLoss(_BaseLoss):
+    """
+    Loss function for dispersion coefficients. Used to train ref_values_C6.
+    """
+    def __init__(self, emle_base, loss=_torch.nn.MSELoss()):
+        super().__init__()
+
+        from ..models._emle_base import EMLEBase
+
+        if not isinstance(emle_base, EMLEBase):
+            raise TypeError("emle_base must be an instance of EMLEBase")
+        self._emle_base = emle_base
+
+        if not isinstance(loss, _torch.nn.Module):
+            raise TypeError("loss must be an instance of torch.nn.Module")
+        self._loss = loss
+        
+        self._pol = None
+
+    def forward(self, atomic_numbers, xyz, q_mol, C6_target):
+        """
+        Forward pass.
+
+        Parameters
+        ----------
+        atomic_numbers: torch.Tensor(N_BATCH, MAX_N_ATOMS)
+            Atomic numbers.
+
+        xyz: torch.Tensor(N_BATCH, MAX_N_ATOMS, 3)
+            Cartesian coordinates.
+        
+        q_mol: torch.Tensor(N_BATCH, MAX_N_ATOMS)
+            Molecular charges.
+
+        C6_target: torch.Tensor(N_BATCH, MAX_N_ATOMS)
+            Target dispersion coefficients.
+        """
+        # Update reference values for C6.
+        self._update_C6_gpr(self._emle_base)
+
+        # Calculate C6.
+        s, q_core, q_val, A_thole, C6 = self._emle_base(atomic_numbers, xyz, q_mol)
+        # Calculate isotropic polarizabilities if not already calculated.
+        if self._pol is None:
+            self._pol = self._emle_base.calculate_isotropic_polarizabilities(A_thole).detach()
+
+        # Mask out dummy atoms. 
+        mask = atomic_numbers > 0
+        target = C6_target[mask]
+        values = C6 
+        values = values[mask] 
+
+        # Calculate loss.
+        loss = self._loss(values, target) 
+
+        return (
+            loss,
+            self._get_rmse(values, target),
+            self._get_max_error(values, target),
+        )
+    
+    @staticmethod
+    def _update_C6_gpr(emle_base):
+        emle_base._ref_mean_C6, emle_base._c_C6 = emle_base._get_c(
+            emle_base._n_ref,
+            emle_base.ref_values_C6,
             emle_base._Kinv,
         )

--- a/emle/train/_loss.py
+++ b/emle/train/_loss.py
@@ -358,9 +358,7 @@ class DispersionCoefficientLoss(_BaseLoss):
         s, q_core, q_val, A_thole, c6 = self._emle_base(atomic_numbers, xyz, q_mol)
         # Calculate isotropic polarizabilities if not already calculated.
         if self._pol is None:
-            self._pol = self._emle_base.get_isotropic_polarizabilities(
-                A_thole
-            ).detach()
+            self._pol = self._emle_base.get_isotropic_polarizabilities(A_thole).detach()
 
         # Mask out dummy atoms.
         mask = atomic_numbers > 0

--- a/emle/train/_loss.py
+++ b/emle/train/_loss.py
@@ -358,7 +358,7 @@ class DispersionCoefficientLoss(_BaseLoss):
         s, q_core, q_val, A_thole, c6 = self._emle_base(atomic_numbers, xyz, q_mol)
         # Calculate isotropic polarizabilities if not already calculated.
         if self._pol is None:
-            self._pol = self._emle_base.calculate_isotropic_polarizabilities(
+            self._pol = self._emle_base.get_isotropic_polarizabilities(
                 A_thole
             ).detach()
 

--- a/emle/train/_trainer.py
+++ b/emle/train/_trainer.py
@@ -566,7 +566,7 @@ class EMLETrainer:
         # Update GPR constants for chi
         # (now inconsistent since not updated after the last epoch)
         self._qeq_loss._update_chi_gpr(emle_base)
-        
+
         _logger.debug(f"Optimized a_QEq: {emle_base.a_QEq.data.item()}")
         # Fit a_Thole, k_Z (uses volumes predicted by QEq model).
         _logger.info("Fitting a_Thole and k_Z values...")
@@ -604,7 +604,7 @@ class EMLETrainer:
             # Update GPR constants for sqrtk
             # (now inconsistent since not updated after the last epoch)
             self._thole_loss._update_sqrtk_gpr(emle_base)
-        
+
         if c6 is not None:
             _logger.info("Fitting ref_values_c6 values...")
             self._train_model(

--- a/emle/train/_trainer.py
+++ b/emle/train/_trainer.py
@@ -545,7 +545,7 @@ class EMLETrainer:
             emle_aev_computer=emle_aev_computer,
             species=species,
             alpha_mode=alpha_mode,
-            lj_mode="static" if c6 is not None else None,
+            lj_mode="fixed",
             device=_torch.device(device),
             dtype=dtype,
         )
@@ -611,7 +611,7 @@ class EMLETrainer:
                 loss_class=self._dispersion_coefficient_loss,
                 opt_param_names=["ref_values_c6"],
                 lr=lr_c6,
-                epochs=1000,
+                epochs=2000,
                 print_every=print_every,
                 emle_base=emle_base,
                 atomic_numbers=z_train,

--- a/emle/train/_trainer.py
+++ b/emle/train/_trainer.py
@@ -31,6 +31,7 @@ from ._gpr import GPR as _GPR
 from ._ivm import IVM as _IVM
 from ._loss import QEqLoss as _QEqLoss
 from ._loss import TholeLoss as _TholeLoss
+from ._loss import DispersionCoefficientLoss as _DispersionCoefficientLoss
 from ._utils import pad_to_max as _pad_to_max
 from ._utils import mean_by_z as _mean_by_z
 
@@ -41,6 +42,7 @@ class EMLETrainer:
         emle_base=_EMLEBase,
         qeq_loss=_QEqLoss,
         thole_loss=_TholeLoss,
+        dispersion_coefficient_loss=_DispersionCoefficientLoss,
         log_level=None,
         log_file=None,
     ):
@@ -55,6 +57,10 @@ class EMLETrainer:
         if thole_loss is not _TholeLoss:
             raise TypeError("thole_loss must be a reference to TholeLoss")
         self._thole_loss = thole_loss
+
+        if dispersion_coefficient_loss is not _DispersionCoefficientLoss:
+            raise TypeError("dispersion_coefficient_loss must be a reference to DispersionCoefficientLoss")
+        self._dispersion_coefficient_loss = dispersion_coefficient_loss
 
         # First handle the logger.
         if log_level is None:
@@ -293,7 +299,8 @@ class EMLETrainer:
         q_core,
         q_val,
         alpha,
-        train_mask,
+        C6=None,
+        train_mask=None,
         alpha_mode="reference",
         sigma=1e-3,
         ivm_thr=0.05,
@@ -301,6 +308,7 @@ class EMLETrainer:
         lr_qeq=0.05,
         lr_thole=0.05,
         lr_sqrtk=0.05,
+        lr_C6=0.05,
         print_every=10,
         computer_n_species=None,
         computer_zid_map=None,
@@ -333,6 +341,9 @@ class EMLETrainer:
         alpha: array or tensor or list of tensor/arrays of shape (N_BATCH, 3, 3)
             Atomic polarizabilities.
 
+        C6: array or tensor or list of tensor/arrays of shape (N_BATCH, N_ATOMS, N_ATOMS)
+            C6 dispersion coefficients. If None, the C6 dispersion coefficients are not trained.
+
         train_mask: torch.Tensor(N_BATCH,)
             Mask for training samples.
 
@@ -356,6 +367,9 @@ class EMLETrainer:
 
         lr_sqrtk: float
             Learning rate for sqrtk.
+
+        lr_C6: float
+            Learning rate for C6.
 
         print_every: int
             How often to print training progress.
@@ -426,6 +440,11 @@ class EMLETrainer:
         q_train = q_train.to(device=device, dtype=dtype)
         alpha_train = alpha_train.to(device=device, dtype=dtype)
         species = species.to(device=device, dtype=_torch.int64)
+
+        if C6 is not None:
+            C6 = _pad_to_max(C6)
+            C6_train = C6[train_mask]
+            C6_train = C6_train.to(device=device, dtype=dtype)
 
         # Get zid mapping.
         zid_mapping = self._get_zid_mapping(species)
@@ -504,6 +523,15 @@ class EMLETrainer:
                 if alpha_mode == "reference"
                 else None
             ),
+            "ref_values_C6": (
+                _torch.ones(
+                    *ref_values_s.shape,
+                    dtype=ref_values_s.dtype,
+                    device=_torch.device(device),
+                )
+                if C6 is not None
+                else None
+            ),
         }
 
         # Create the EMLE base instance.
@@ -515,10 +543,10 @@ class EMLETrainer:
             emle_aev_computer=emle_aev_computer,
             species=species,
             alpha_mode=alpha_mode,
+            lj_mode="static" if C6 is not None else None,
             device=_torch.device(device),
             dtype=dtype,
         )
-
         # Fit chi, a_QEq (QEq over chi predicted with GPR).
         _logger.info("Fitting a_QEq and chi values...")
         self._train_model(
@@ -536,9 +564,8 @@ class EMLETrainer:
         # Update GPR constants for chi
         # (now inconsistent since not updated after the last epoch)
         self._qeq_loss._update_chi_gpr(emle_base)
-
+        """
         _logger.debug(f"Optimized a_QEq: {emle_base.a_QEq.data.item()}")
-
         # Fit a_Thole, k_Z (uses volumes predicted by QEq model).
         _logger.info("Fitting a_Thole and k_Z values...")
         self._train_model(
@@ -575,6 +602,24 @@ class EMLETrainer:
             # Update GPR constants for sqrtk
             # (now inconsistent since not updated after the last epoch)
             self._thole_loss._update_sqrtk_gpr(emle_base)
+        """
+        if C6 is not None:
+            _logger.info("Fitting ref_values_C6 values...")
+            self._train_model(
+                loss_class=self._dispersion_coefficient_loss,
+                opt_param_names=["ref_values_C6"],
+                lr=lr_C6,
+                epochs=1000,
+                print_every=print_every,
+                emle_base=emle_base,
+                atomic_numbers=z_train,
+                xyz=xyz_train,
+                q_mol=q_mol_train,
+                C6_target=C6_train,
+            )
+
+            # Update reference values for C6.
+            self._dispersion_coefficient_loss._update_C6_gpr(emle_base)
 
         # Create the final model.
         emle_model = {
@@ -586,6 +631,9 @@ class EMLETrainer:
             "k_Z": emle_base.k_Z,
             "sqrtk_ref": (
                 emle_base.ref_values_sqrtk if alpha_mode == "reference" else None
+            ),
+            "ref_values_C6": (
+                emle_base.ref_values_C6 if C6 is not None else None
             ),
             "species": species,
             "alpha_mode": alpha_mode,
@@ -603,11 +651,17 @@ class EMLETrainer:
             return emle_base
 
         emle_base._alpha_mode = "species"
-        s_pred, q_core_pred, q_val_pred, A_thole = emle_base(
+        emle_base_output = emle_base(
             z.to(device=device, dtype=_torch.int64),
             xyz.to(device=device, dtype=dtype),
             q_mol,
         )
+        
+        s_pred = emle_base_output[0]
+        q_core_pred = emle_base_output[1]
+        q_val_pred = emle_base_output[2]
+        A_thole = emle_base_output[3]
+
         z_mask = _torch.tensor(z > 0, device=device)
         plot_data = {
             "s_emle": s_pred,
@@ -631,6 +685,10 @@ class EMLETrainer:
             plot_data["alpha_reference"] = self._thole_loss._get_alpha_mol(
                 A_thole, z_mask
             )
+    
+        if C6 is not None:
+            C6_pred = emle_base_output[4]
+            plot_data["C6_emle"] = C6_pred
 
         self._write_model_to_file(plot_data, plot_data_filename)
 

--- a/emle/train/_trainer.py
+++ b/emle/train/_trainer.py
@@ -59,7 +59,9 @@ class EMLETrainer:
         self._thole_loss = thole_loss
 
         if dispersion_coefficient_loss is not _DispersionCoefficientLoss:
-            raise TypeError("dispersion_coefficient_loss must be a reference to DispersionCoefficientLoss")
+            raise TypeError(
+                "dispersion_coefficient_loss must be a reference to DispersionCoefficientLoss"
+            )
         self._dispersion_coefficient_loss = dispersion_coefficient_loss
 
         # First handle the logger.
@@ -273,7 +275,7 @@ class EMLETrainer:
                 optimizer.step()
                 if (epoch + 1) % print_every == 0:
                     _logger.info(
-                        f"Epoch {epoch+1}: Loss ={loss.item():9.4f}    "
+                        f"Epoch {epoch + 1}: Loss ={loss.item():9.4f}    "
                         f"RMSE ={rmse.item():9.4f}    "
                         f"Max Error ={max_error.item():9.4f}"
                     )
@@ -632,9 +634,7 @@ class EMLETrainer:
             "sqrtk_ref": (
                 emle_base.ref_values_sqrtk if alpha_mode == "reference" else None
             ),
-            "ref_values_C6": (
-                emle_base.ref_values_C6 if C6 is not None else None
-            ),
+            "ref_values_C6": (emle_base.ref_values_C6 if C6 is not None else None),
             "species": species,
             "alpha_mode": alpha_mode,
             "n_ref": n_ref,
@@ -656,7 +656,7 @@ class EMLETrainer:
             xyz.to(device=device, dtype=dtype),
             q_mol,
         )
-        
+
         s_pred = emle_base_output[0]
         q_core_pred = emle_base_output[1]
         q_val_pred = emle_base_output[2]
@@ -685,7 +685,7 @@ class EMLETrainer:
             plot_data["alpha_reference"] = self._thole_loss._get_alpha_mol(
                 A_thole, z_mask
             )
-    
+
         if C6 is not None:
             C6_pred = emle_base_output[4]
             plot_data["C6_emle"] = C6_pred

--- a/versioneer.py
+++ b/versioneer.py
@@ -514,9 +514,7 @@ def run_command(
     return stdout, process.returncode
 
 
-LONG_VERSION_PY[
-    "git"
-] = r'''
+LONG_VERSION_PY["git"] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -1840,9 +1838,9 @@ def get_versions(verbose: bool = False) -> Dict[str, Any]:
     handlers = HANDLERS.get(cfg.VCS)
     assert handlers, "unrecognized VCS '%s'" % cfg.VCS
     verbose = verbose or bool(cfg.verbose)  # `bool()` used to avoid `None`
-    assert (
-        cfg.versionfile_source is not None
-    ), "please set versioneer.versionfile_source"
+    assert cfg.versionfile_source is not None, (
+        "please set versioneer.versionfile_source"
+    )
     assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
 
     versionfile_abs = os.path.join(root, cfg.versionfile_source)


### PR DESCRIPTION
This PR adds the Lennard-Jones EMLE, enabling it to function as a fully coupled scheme in which both electrostatics and dispersion are handled by emle-engine. There are two LJ modes:

- `flexible`: the LJ parameters for the ML region are determined on-the-fly and are geometry-dependent
- `fixed`: the LJ parameters for the ML region are fixed, and can either be provided by the user or determined from a given geometry (e.g., an optimised structure)

The main change compared to how the code worked before is that the forward pass of `EMLE` now always returns the LJ energy as the last output, which will be zero if no LJ mode is specified (the default). Everything else remains the same, meaning that old scripts should still work, as all LJ settings are optional.

I've also added training routines for the required parameters. The learned property is the dispersion coefficient (e.g., C6), so one value per reference AEV is added to the model and learned by direct fitting to the targets.

I'm still expecting some changes in the future as this is being tested, so I'll leave this as a draft for now. Compatibility with Sander still needs to be added.
