### PR TITLE
Fix issue #61

### DIFF
--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -215,7 +215,7 @@ class MACEEMLE(_torch.nn.Module):
             target_model = source_model.__class__(**config).to(device)
 
             # Load the state dict.
-            target_model.load_state_dict(source_model.state_dict())
+            target_model.load_state_dict(source_model.state_dict(), strict=False)
 
             # Compile the model.
             self._mace_models.append(_e3nn_jit.compile(target_model).to(self._dtype))


### PR DESCRIPTION
This PR closes #61 by using `strict=False` when loading the state dict of an existing MACE model. This allows the use of old models with a newer version of MACE, where the new state dict might contain additional keys that weren't present in the old version.