### PR TITLE
Fix signature mismatch in sire callback

### DIFF
--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1445,7 +1445,7 @@ class EMLECalculator:
         # Reset the first step flag.
         self._is_first_step = not self._restart
 
-    def _sire_callback(self, atomic_numbers, charges_mm, xyz_qm, xyz_mm, idx_mm=None):
+    def _sire_callback(self, atomic_numbers, charges_mm, xyz_qm, xyz_mm, cell=None, idx_mm=None):
         """
         A callback function to be used with Sire.
 
@@ -1463,6 +1463,9 @@ class EMLECalculator:
 
         xyz_mm: [[float, float, float]]
             The coordinates of the MM atoms in Angstrom.
+
+        cell: [float]
+            PBC cell dimensions
 
         idx_mm: [int]
             A list of indices of the MM atoms in the QM/MM region.


### PR DESCRIPTION
Currently OpenMM implementation is broken due to missing "cell" argument in sire callback. This fIxes it.