### PR TITLE
EMLETrainer fixes

### DIFF
--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -220,6 +220,7 @@ class EMLEBase(_torch.nn.Module):
             raise TypeError("All elements of 'species' must be of type 'int'")
         if not all(s > 0 for s in species):
             raise ValueError("All elements of 'species' must be greater than zero")
+        self._species = species
 
         # Create a map between species and their indices in the model.
         species_map = _np.full(max(species) + 2, fill_value=-1, dtype=_np.int64)

--- a/emle/train/_trainer.py
+++ b/emle/train/_trainer.py
@@ -699,7 +699,7 @@ class EMLETrainer:
         if train_thole:
             plot_data.update(
                 {
-                    "alpha_species": self._thole_loss._get_alpha_mol(A_thole, z_mask),
+                    "alpha_species": self._thole_loss._get_alpha_mol(A_thole, z_mask)[0],
                     "alpha_qm": alpha,
                 }
             )
@@ -719,7 +719,7 @@ class EMLETrainer:
             )
             plot_data["alpha_reference"] = self._thole_loss._get_alpha_mol(
                 A_thole, z_mask
-            )
+            )[0]
 
             if alpha_atomic is not None:
                 plot_data["alpha_atomic_reference_emle"] = (


### PR DESCRIPTION
Fixes two bugs:
1. `plot_data` serialization was broken due to `_thole_loss._get_alpha_mol` returning a tuple `(alpha_mol, A_thole_inv)` instead of just `alpha_mol`
2. `species` provided to `EMLEBase` was not overriding the class default. Because of this, the default value (`[1, 6, 7, 8, 16]`) was ending up in the trained model file