### PR TITLE
Pass total QM charge to _calculate_energy_and_gradients inside sire c…

### DIFF
--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1530,6 +1530,7 @@ class EMLECalculator:
             xyz_qm,
             xyz_mm,
             cell=cell,
+            charge=self._qm_charge
         )
 
         # Store the number of MM atoms.


### PR DESCRIPTION
Total charge was not passed to `_calculate_energy_and_gradients` in `EMLECalculator._sire_callback`, fixes it. Since the default for `qm_charge` is 0 in the `EMLECalculator` constructor, did not put any additional check for `None` (the only way it can become `None` is if someone explicitly provides it as such, which would make no sense).