### PR TITLE
Add emle-mace backend, MACEEMLEJoint model, and ORCA data utilities

### DIFF
--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -76,6 +76,11 @@ parser.add_argument(
     help="Total charge of the QM region",
 )
 parser.add_argument(
+    "--use-dipoles",
+    action="store_true",
+    help="Whether to include static atomic dipoles",
+)
+parser.add_argument(
     "--start",
     type=int,
     help="Structure index to start parsing",
@@ -98,7 +103,7 @@ from emle._orca_parser import ORCAParser
 if args.backend == "deepmd" and not args.deepmd_model:
     parser.error("--deepmd-model is required when backend='deepmd'")
 if args.backend == "mace" and not args.mace_model:
-    parser.error("--mace-model is required when backend='mace'")
+    parser.error("--mace-model is required when backend is 'mace' or 'maceemle'")
 
 backend = None
 if args.backend == "torchani":
@@ -132,7 +137,7 @@ if args.orca_tarball:
     orca_parser = ORCAParser(args.orca_tarball, decompose=True, alpha=args.alpha)
 
 analyzer = EMLEAnalyzer(args.qm_xyz, args.pc_xyz, emle_base, backend, orca_parser,
-                        args.q_total, start=args.start, end=args.end)
+                        args.q_total, args.use_dipoles, start=args.start, end=args.end)
 
 result = {
     "z": analyzer.atomic_numbers,
@@ -145,6 +150,9 @@ result = {
     "atomic_alpha_emle": analyzer.atomic_alpha,
     "alpha_emle": analyzer.alpha,
 }
+if args.use_dipoles:
+    result["mu_emle"] = analyzer.mu
+    result["E_static_mu_emle"] = analyzer.e_static_mu
 
 if orca_parser:
     result.update({
@@ -158,6 +166,8 @@ if orca_parser:
         "q_val_qm": orca_parser.mbis["q_val"],
         "E_static_mbis": analyzer.e_static_mbis,
     })
+    if args.use_dipoles:
+        result['mu_qm'] = orca_parser.mbis["mu"]
 
 if args.backend:
     result["E_vac_emle"] = analyzer.e_backend

--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -185,6 +185,7 @@ if orca_parser:
 
 if args.backend:
     result["E_vac_emle"] = analyzer.e_backend
+    result["grad_vac_emle"] = analyzer.grad_backend
 if args.alpha:
     result["alpha_qm"] = orca_parser.alpha
 

--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -36,14 +36,14 @@ parser.add_argument(
 parser.add_argument(
     "--backend",
     type=str,
-    choices=["torchani", "mace", "deepmd"],
+    choices=["torchani", "mace", "maceemle", "deepmd"],
     help="Gas phase ML backend",
 )
 parser.add_argument(
     "--deepmd-model",
     type=str,
     metavar="name.pb",
-    help="DeePMD model file(s) (for backend='deepmd')",
+    help="MACE model file (for 'mace' and 'maceemle' backends)",
 )
 parser.add_argument(
     "--mace-model",
@@ -109,6 +109,11 @@ elif args.backend == "mace":
     from emle.models import MACEEMLE
 
     backend = MACEEMLE(emle_model=args.emle_model, mace_model=args.mace_model)
+
+elif args.backend == "maceemle":
+    from emle.models import MACEEMLEJoint
+
+    backend = MACEEMLEJoint(emle_model=args.emle_model, mace_model=args.mace_model)
 
 elif args.backend == "maceemle":
     from emle.models import MACEEMLEJoint

--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -73,6 +73,7 @@ parser.add_argument(
 parser.add_argument(
     "--q-total",
     type=int,
+    default=0,
     help="Total charge of the QM region",
 )
 parser.add_argument(
@@ -118,7 +119,9 @@ elif args.backend == "mace":
 elif args.backend == "maceemle":
     from emle.models import MACEEMLEJoint
 
-    backend = MACEEMLEJoint(emle_model=args.emle_model, mace_model=args.mace_model)
+    backend = MACEEMLEJoint(emle_model=args.emle_model,
+                            mace_model=args.mace_model,
+                            qm_charge=args.q_total)
 
 elif args.backend == "maceemle":
     from emle.models import MACEEMLEJoint

--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -43,12 +43,12 @@ parser.add_argument(
     "--deepmd-model",
     type=str,
     metavar="name.pb",
-    help="MACE model file (for 'mace' and 'emle-mace' backends)",
+    help="DeePMD model file(s) (for backend='deepmd')",
 )
 parser.add_argument(
     "--mace-model",
     type=str,
-    help="MACE model file (for backend='mace')",
+    help="MACE model file (for 'mace' and 'maceemle' backends)",
 )
 parser.add_argument(
     "--qm-xyz", type=str, metavar="name.xyz", required=True, help="QM xyz file"

--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -48,7 +48,7 @@ parser.add_argument(
 parser.add_argument(
     "--mace-model",
     type=str,
-    help="MACE model file (for 'mace' and 'maceemle' backends)",
+    help="MACE model file (for 'mace' and 'emle-mace' backends)",
 )
 parser.add_argument(
     "--qm-xyz", type=str, metavar="name.xyz", required=True, help="QM xyz file"

--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -36,14 +36,14 @@ parser.add_argument(
 parser.add_argument(
     "--backend",
     type=str,
-    choices=["torchani", "mace", "maceemle", "deepmd"],
+    choices=["torchani", "mace", "emle-mace", "deepmd"],
     help="Gas phase ML backend",
 )
 parser.add_argument(
     "--deepmd-model",
     type=str,
     metavar="name.pb",
-    help="MACE model file (for 'mace' and 'maceemle' backends)",
+    help="MACE model file (for 'mace' and 'emle-mace' backends)",
 )
 parser.add_argument(
     "--mace-model",
@@ -103,8 +103,8 @@ from emle._orca_parser import ORCAParser
 
 if args.backend == "deepmd" and not args.deepmd_model:
     parser.error("--deepmd-model is required when backend='deepmd'")
-if args.backend == "mace" and not args.mace_model:
-    parser.error("--mace-model is required when backend is 'mace' or 'maceemle'")
+if args.backend in ("mace", "emle-mace") and not args.mace_model:
+    parser.error("--mace-model is required when backend is 'mace' or 'emle-mace'")
 
 backend = None
 if args.backend == "torchani":
@@ -116,17 +116,12 @@ elif args.backend == "mace":
 
     backend = MACEEMLE(emle_model=args.emle_model, mace_model=args.mace_model)
 
-elif args.backend == "maceemle":
+elif args.backend == "emle-mace":
     from emle.models import MACEEMLEJoint
 
     backend = MACEEMLEJoint(emle_model=args.emle_model,
                             mace_model=args.mace_model,
                             qm_charge=args.q_total)
-
-elif args.backend == "maceemle":
-    from emle.models import MACEEMLEJoint
-
-    backend = MACEEMLEJoint(emle_model=args.emle_model, mace_model=args.mace_model)
 
 elif args.backend == "deepmd":
     from emle._backends import DeePMD

--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -119,9 +119,11 @@ elif args.backend == "mace":
 elif args.backend == "emle-mace":
     from emle.models import MACEEMLEJoint
 
-    backend = MACEEMLEJoint(emle_model=args.emle_model,
-                            mace_model=args.mace_model,
-                            qm_charge=args.q_total)
+    backend = MACEEMLEJoint(
+        emle_model=args.emle_model,
+        mace_model=args.mace_model,
+        qm_charge=args.q_total,
+    )
 
 elif args.backend == "deepmd":
     from emle._backends import DeePMD
@@ -176,7 +178,7 @@ if orca_parser:
         }
     )
     if args.use_dipoles:
-        result['mu_qm'] = orca_parser.mbis["mu"]
+        result["mu_qm"] = orca_parser.mbis["mu"]
 
 if args.backend:
     result["E_vac_emle"] = analyzer.e_backend

--- a/bin/emle-server
+++ b/bin/emle-server
@@ -61,6 +61,10 @@ except:
 model = os.getenv("EMLE_MODEL")
 method = os.getenv("EMLE_METHOD")
 alpha_mode = os.getenv("EMLE_ALPHA_MODE")
+try:
+    use_dipoles = strtobool(os.getenv("EMLE_USE_DIPOLES"))
+except:
+    use_dipoles = False
 atomic_numbers = os.getenv("EMLE_ATOMIC_NUMBERS")
 mm_charges = os.getenv("EMLE_MM_CHARGES")
 try:
@@ -144,6 +148,7 @@ env = {
     "model": model,
     "method": method,
     "alpha_mode": alpha_mode,
+    "use_dipoles": use_dipoles,
     "atomic_numbers": atomic_numbers,
     "mm_charges": mm_charges,
     "num_clients": num_clients,

--- a/bin/tarball-to-extxyz
+++ b/bin/tarball-to-extxyz
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from emle._tarball_to_extXYZ import main
+
+if __name__ == "__main__":
+    main()

--- a/emle/__init__.py
+++ b/emle/__init__.py
@@ -36,6 +36,7 @@ molecular systems.
 _supported_backends = [
     "torchani",
     "mace",
+    "maceemle",
     "ace",
     "deepmd",
     "orca",

--- a/emle/__init__.py
+++ b/emle/__init__.py
@@ -36,7 +36,7 @@ molecular systems.
 _supported_backends = [
     "torchani",
     "mace",
-    "maceemle",
+    "emle-mace",
     "ace",
     "deepmd",
     "orca",

--- a/emle/_analyzer.py
+++ b/emle/_analyzer.py
@@ -151,7 +151,7 @@ class EMLEAnalyzer:
                 charges_mm = _torch.empty((len(qm_xyz), 0), dtype=dtype, device=device)
                 mm_xyz = _torch.empty((len(qm_xyz), 0, 3), dtype=dtype, device=device)
             self.e_backend = (
-                backend(atomic_numbers, charges_mm, qm_xyz, mm_xyz).T
+                backend(atomic_numbers, charges_mm, qm_xyz, mm_xyz, qm_charge=q_total).T
                 * _HARTREE_TO_KCAL_MOL
             )
 

--- a/emle/_analyzer.py
+++ b/emle/_analyzer.py
@@ -163,15 +163,13 @@ class EMLEAnalyzer:
         self.pc_charges = _torch.tensor(pc_charges, dtype=dtype, device=device)
         self.pc_xyz = _torch.tensor(pc_xyz, dtype=dtype, device=device)
 
-        # TODO: naming differs from EMLE.forward, unify
         qm_xyz_bohr = self.qm_xyz * _ANGSTROM_TO_BOHR
         pc_xyz_bohr = self.pc_xyz * _ANGSTROM_TO_BOHR
 
         if isinstance(backend, MACEEMLEJoint):
             self.s = _torch.stack(backend.emle_values['s'])
             self.q_core = _torch.stack(backend.emle_values['q_core'])
-            self.q = _torch.stack(backend.emle_values['q'])
-            self.q_val = self.q - self.q_core
+            self.q_val = _torch.stack(backend.emle_values['q_val'])
             self.mu = _torch.stack(backend.emle_values['mu'])
 
             a_Thole = backend._mace.a_Thole

--- a/emle/_analyzer.py
+++ b/emle/_analyzer.py
@@ -33,7 +33,7 @@ import torch as _torch
 
 from ._units import _HARTREE_TO_KCAL_MOL, _ANGSTROM_TO_BOHR
 from ._utils import pad_to_max as _pad_to_max
-from .models import MACEEMLEJoint
+from .models import MACEEMLEJoint as _MACEEMLEJoint
 
 
 class EMLEAnalyzer:
@@ -170,7 +170,7 @@ class EMLEAnalyzer:
         qm_xyz_bohr = self.qm_xyz * _ANGSTROM_TO_BOHR
         pc_xyz_bohr = self.pc_xyz * _ANGSTROM_TO_BOHR
 
-        if isinstance(backend, MACEEMLEJoint):
+        if isinstance(backend, _MACEEMLEJoint):
             self.s = _torch.stack(backend.emle_values["s"])
             self.q_core = _torch.stack(backend.emle_values["q_core"])
             self.q_val = _torch.stack(backend.emle_values["q_val"])

--- a/emle/_analyzer.py
+++ b/emle/_analyzer.py
@@ -147,14 +147,18 @@ class EMLEAnalyzer:
             if isinstance(backend, _torch.nn.Module):
                 backend = backend.to(device).to(dtype)
                 atomic_numbers = _torch.tensor(atomic_numbers, device=device)
-                qm_xyz = _torch.tensor(qm_xyz, dtype=dtype, device=device, requires_grad=True)
+                qm_xyz = _torch.tensor(
+                    qm_xyz, dtype=dtype, device=device, requires_grad=True
+                )
                 charges_mm = _torch.empty((len(qm_xyz), 0), dtype=dtype, device=device)
                 mm_xyz = _torch.empty((len(qm_xyz), 0, 3), dtype=dtype, device=device)
             self.e_backend = (
                 backend(atomic_numbers, charges_mm, qm_xyz, mm_xyz, qm_charge=q_total).T
                 * _HARTREE_TO_KCAL_MOL
             )
-            self.grad_backend = _torch.autograd.grad(self.e_backend.T[0].sum(), qm_xyz)[0]
+            self.grad_backend = _torch.autograd.grad(self.e_backend.T[0].sum(), qm_xyz)[
+                0
+            ]
 
         self.atomic_numbers = _torch.tensor(
             atomic_numbers, dtype=_torch.int, device=device
@@ -167,10 +171,10 @@ class EMLEAnalyzer:
         pc_xyz_bohr = self.pc_xyz * _ANGSTROM_TO_BOHR
 
         if isinstance(backend, MACEEMLEJoint):
-            self.s = _torch.stack(backend.emle_values['s'])
-            self.q_core = _torch.stack(backend.emle_values['q_core'])
-            self.q_val = _torch.stack(backend.emle_values['q_val'])
-            self.mu = _torch.stack(backend.emle_values['mu'])
+            self.s = _torch.stack(backend.emle_values["s"])
+            self.q_core = _torch.stack(backend.emle_values["q_core"])
+            self.q_val = _torch.stack(backend.emle_values["q_val"])
+            self.mu = _torch.stack(backend.emle_values["mu"])
 
             a_Thole = backend._mace.a_Thole
             species_id = emle_base._species_map[self.atomic_numbers]
@@ -185,7 +189,7 @@ class EMLEAnalyzer:
                 self.qm_xyz,
                 self.q_total,
             )
-        self.atomic_alpha = 1. / _torch.diagonal(self.A_thole, dim1=1, dim2=2)[:, ::3]
+        self.atomic_alpha = 1.0 / _torch.diagonal(self.A_thole, dim1=1, dim2=2)[:, ::3]
         self.alpha = self._get_mol_alpha(self.A_thole, self.atomic_numbers)
 
         mask = (self.atomic_numbers > 0).unsqueeze(-1)
@@ -198,10 +202,10 @@ class EMLEAnalyzer:
         )
         if use_dipoles:
             self.e_static_mu = (
-                    emle_base.get_static_energy(
-                        self.q_core, self.q_val, self.pc_charges, mesh_data, self.mu
-                    )
-                    * _HARTREE_TO_KCAL_MOL
+                emle_base.get_static_energy(
+                    self.q_core, self.q_val, self.pc_charges, mesh_data, self.mu
+                )
+                * _HARTREE_TO_KCAL_MOL
             )
         self.e_induced = (
             emle_base.get_induced_energy(

--- a/emle/_orca_parser.py
+++ b/emle/_orca_parser.py
@@ -33,9 +33,7 @@ import numpy as _np
 import tarfile as _tarfile
 
 from ._utils import pad_to_max
-
-_HARTREE_TO_KCALMOL = 627.509
-_HARTREE_BOHR_TO_EV_A = 27.2114/0.529177
+from ._units import _HARTREE_TO_KCAL_MOL, _HARTREE_BOHR_TO_EV_A 
 
 class ORCAParser:
     """
@@ -168,13 +166,13 @@ class ORCAParser:
     def _get_E_from_out(self, f):
         E_prefix = b"FINAL SINGLE POINT ENERGY"
         E_line = next(line for line in f if line.startswith(E_prefix))
-        return float(E_line.split()[-1]) * _HARTREE_TO_KCALMOL
+        return float(E_line.split()[-1]) * _HARTREE_TO_KCAL_MOL
 
     def _get_E_static(self):
         vpot_all = self._get_vpot()
         pc_all = self._get_pc()
         result = _np.array([(vpot @ pc) for vpot, pc in zip(vpot_all, pc_all)])
-        return result * _HARTREE_TO_KCALMOL
+        return result * _HARTREE_TO_KCAL_MOL
 
     def _get_vpot(self):
         return [

--- a/emle/_orca_parser.py
+++ b/emle/_orca_parser.py
@@ -33,7 +33,8 @@ import numpy as _np
 import tarfile as _tarfile
 
 from ._utils import pad_to_max
-from ._units import _HARTREE_TO_KCAL_MOL, _HARTREE_BOHR_TO_EV_A 
+from ._units import _HARTREE_TO_KCAL_MOL, _HARTREE_BOHR_TO_EV_A
+
 
 class ORCAParser:
     """
@@ -252,8 +253,18 @@ class ORCAParser:
 
     def _get_file(self, name, suffix):
         return self._tar.extractfile(f"{name}.{suffix}")
-    
+
     def get_E_vac(self):
+        """
+        Parse the gas-phase ORCA output for each configuration and return the
+        total energy in Hartree.
+
+        Returns
+        -------
+
+        E_tot: numpy.ndarray (N_CONFIGS,)
+            Total gas-phase energy per configuration, in Hartree.
+        """
         E_tot = [
             self._get_E_vac_from_out(self._get_file(name, "vac.orca"))
             for name in self.names
@@ -261,22 +272,38 @@ class ORCAParser:
         return _np.array(E_tot)
 
     def _get_E_vac_from_out(self, f):
+        """
+        Extract the total energy from an ORCA gas-phase output file.
+        """
         E_prefix = b"Total Energy       :"
         E_line = [line for line in f if line.startswith(E_prefix)]
         return float(E_line[0].split()[-2])
 
-
     def get_forces(self):
+        """
+        Parse the gas-phase ORCA output for each configuration and return the
+        atomic forces in eV/Angstrom.
+
+        Returns
+        -------
+
+        forces: List[numpy.ndarray]
+            Per-configuration atomic forces, each of shape (N_ATOMS, 3).
+        """
         forces = [
             self._get_forces_from_out(self._get_file(name, "vac.orca"))
             for name in self.names
         ]
         return forces
 
-
     def _get_forces_from_out(self, f):
+        """
+        Extract the Cartesian forces from an ORCA gas-phase output file.
+        Returns forces in eV/Angstrom (ORCA reports the gradient in Hartree/Bohr;
+        we negate and convert).
+        """
         while next(f) != b"CARTESIAN GRADIENT\n":
-                pass
+            pass
         next(f)
         next(f)
         forces = []
@@ -285,10 +312,13 @@ class ORCAParser:
                 line_elements = next(f).split()
                 if len(line_elements) == 0:
                     break
-                # Extract gradient (last 3 elements) and convert to forces in eV/A
-                force_values = [float(f) * _HARTREE_BOHR_TO_EV_A * (-1) for f in line_elements[-3:]]
+                # Extract gradient (last 3 elements) and convert to forces in eV/A.
+                force_values = [
+                    float(x) * _HARTREE_BOHR_TO_EV_A * (-1)
+                    for x in line_elements[-3:]
+                ]
                 forces.append(force_values)
 
         except ValueError:
             pass
-        return _np.asarray(forces) 
+        return _np.asarray(forces)

--- a/emle/_orca_parser.py
+++ b/emle/_orca_parser.py
@@ -33,7 +33,7 @@ import numpy as _np
 import tarfile as _tarfile
 
 from ._utils import pad_to_max
-from ._units import _HARTREE_TO_KCAL_MOL, _HARTREE_BOHR_TO_EV_A
+from ._units import _HARTREE_TO_KCAL_MOL
 
 
 class ORCAParser:
@@ -282,13 +282,14 @@ class ORCAParser:
     def get_forces(self):
         """
         Parse the gas-phase ORCA output for each configuration and return the
-        atomic forces in eV/Angstrom.
+        atomic forces in Hartree/Bohr.
 
         Returns
         -------
 
         forces: List[numpy.ndarray]
-            Per-configuration atomic forces, each of shape (N_ATOMS, 3).
+            Per-configuration atomic forces in Hartree/Bohr, each of shape
+            (N_ATOMS, 3).
         """
         forces = [
             self._get_forces_from_out(self._get_file(name, "vac.orca"))
@@ -299,8 +300,8 @@ class ORCAParser:
     def _get_forces_from_out(self, f):
         """
         Extract the Cartesian forces from an ORCA gas-phase output file.
-        Returns forces in eV/Angstrom (ORCA reports the gradient in Hartree/Bohr;
-        we negate and convert).
+        ORCA reports the gradient in Hartree/Bohr; we negate (forces =
+        -gradient) and return in the same units.
         """
         while next(f) != b"CARTESIAN GRADIENT\n":
             pass
@@ -312,11 +313,8 @@ class ORCAParser:
                 line_elements = next(f).split()
                 if len(line_elements) == 0:
                     break
-                # Extract gradient (last 3 elements) and convert to forces in eV/A.
-                force_values = [
-                    float(x) * _HARTREE_BOHR_TO_EV_A * (-1)
-                    for x in line_elements[-3:]
-                ]
+                # Extract gradient (last 3 elements) and negate to get forces.
+                force_values = [-float(x) for x in line_elements[-3:]]
                 forces.append(force_values)
 
         except ValueError:

--- a/emle/_tarball_to_extXYZ.py
+++ b/emle/_tarball_to_extXYZ.py
@@ -1,0 +1,206 @@
+"""Functions for converting ORCA tarball files to extXYZ format."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import ase.io
+from ase import Atoms
+from ase.data import chemical_symbols
+
+from ._orca_parser import ORCAParser
+
+
+def orca_to_extxyz(orca_tarball_path, output_path=None, total_charge=0, 
+                   parse_alpha=True, verbose=False):
+    """
+    Convert ORCA tarball to extXYZ format using ORCAParser and ASE.
+    
+    Parameters:
+    -----------
+    orca_tarball_path : str or Path
+        Path to the ORCA tarball file
+    output_path : str or Path, optional
+        Output path for the extXYZ file. If None, uses input name with .xyz extension
+    total_charge : int, optional
+        Total charge of the system (default: 0)
+    parse_alpha : bool, optional
+        Whether to parse polarizability data (default: True)
+    verbose : bool, optional
+        Enable verbose output (default: False)
+    
+    Returns:
+    --------
+    str : Path to the created extXYZ file
+    """
+    orca_tarball_path = Path(orca_tarball_path)
+    
+    if not orca_tarball_path.exists():
+        raise FileNotFoundError(f"ORCA tarball not found: {orca_tarball_path}")
+    
+    # Set output path if not provided
+    if output_path is None:
+        output_path = orca_tarball_path.with_suffix('.xyz')
+    else:
+        output_path = Path(output_path)
+    
+    if verbose:
+        print(f"Parsing ORCA tarball: {orca_tarball_path}")
+    
+    # Initialize ORCA parser
+    parser = ORCAParser(str(orca_tarball_path), alpha=parse_alpha)
+    
+    if verbose:
+        print(f"Parser attributes: {list(parser.__dict__.keys())}")
+    
+    # Get number of frames from parser data
+    if not (hasattr(parser, 'xyz') and parser.xyz is not None):
+        raise ValueError("XYZ data not available in parser")
+    
+    n_frames = len(parser.xyz)
+    if verbose:
+        print(f"Found {n_frames} frames")
+
+    # Convert atomic numbers to symbols
+    atomic_numbers = parser.z[0]
+    symbols = [chemical_symbols[int(z)] for z in atomic_numbers]
+
+    # Create atoms list
+    atoms_list = []
+    
+    for i in range(n_frames):
+        frame_number = i + 1
+        
+        # Create ASE atoms object from parser data
+        atoms = Atoms(symbols=symbols, positions=parser.xyz[i])
+
+        # Add forces
+        atoms.arrays['forces_dft'] = parser.forces[i]
+
+        # Add MBIS properties
+        if not (hasattr(parser, 'mbis') and parser.mbis is not None):
+            raise ValueError("MBIS data not available in parser")
+        
+        # Core charges, chek if it's present and available for all frames
+        if not ('q_core' in parser.mbis and len(parser.mbis['q_core']) > i):
+            raise ValueError(f"Core charges not available for frame {frame_number}")
+        q_core = parser.mbis['q_core'][i]
+        
+        # Valence charges
+        if not ('q_val' in parser.mbis and len(parser.mbis['q_val']) > i):
+            raise ValueError(f"Valence charges not available for frame {frame_number}")
+        q_val = parser.mbis['q_val'][i]
+        
+        # Add q_core and q_val
+        atoms.arrays['q_core'] = q_core
+        atoms.arrays['q_val'] = q_val
+
+        # Total charges
+        atoms.arrays['q'] = q_core + q_val
+        
+        # Dipole moments (mu)
+        if not ('mu' in parser.mbis and len(parser.mbis['mu']) > i):
+            raise ValueError(f"Dipole moments not available for frame {frame_number}")
+        atoms.arrays['mu'] = parser.mbis['mu'][i]
+        
+        # Valence width (s)
+        if not ('s' in parser.mbis and len(parser.mbis['s']) > i):
+            raise ValueError(f"Valence width not available for frame {frame_number}")
+        atoms.arrays['s'] = parser.mbis['s'][i]
+        
+        # Add energy 
+        if parser.E_vac is None:
+            raise ValueError(f"E_vac not available for frame {frame_number}")
+
+        # Set system properties 
+        atoms.info['pos_unit'] = 'angstrom'
+        atoms.info['energy_dft'] = parser.E_vac[i]
+        atoms.info['total_charge'] = total_charge
+        atoms.info['pbc'] = "F F F"
+              
+        # Add polarizability
+        if parse_alpha:
+            if not (hasattr(parser, 'alpha') and parser.alpha is not None and len(parser.alpha) > i):
+                raise ValueError(f"Polarizability not available for frame {frame_number}")
+            
+            alpha_tensor = parser.alpha[i]
+            if isinstance(alpha_tensor, np.ndarray) and alpha_tensor.shape == (3, 3):
+                alpha_json = f"_JSON {alpha_tensor.tolist()}"
+                atoms.info['alpha'] = alpha_json
+            else:
+                raise ValueError(f"Unexpected polarizability format for frame {frame_number}: {type(alpha_tensor)}, shape: {getattr(alpha_tensor, 'shape', 'N/A')}")
+        
+        atoms_list.append(atoms)
+    
+    if verbose:
+        print(f"Writing extXYZ file: {output_path}")
+    
+    # Write to extXYZ format
+    ase.io.write(str(output_path), atoms_list, format='extxyz')
+    
+    if verbose:
+        print(f"Successfully created extXYZ file with {len(atoms_list)} frames")
+    
+    return str(output_path)
+
+
+def main():
+    """Command line interface for the ORCA tarball to extXYZ converter."""
+    import argparse
+    
+    parser = argparse.ArgumentParser(
+        description="Convert ORCA tarball files to extXYZ format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="LK, 11/10/2025"
+    )
+    
+    parser.add_argument(
+        'input',
+        help='Input ORCA tarball file path'
+    )
+    
+    parser.add_argument(
+        '-o', '--output',
+        help='Output extXYZ file path (default: input_name.xyz)'
+    )
+    
+    parser.add_argument(
+        '--charge',
+        type=int,
+        default=0,
+        help='Total charge of the system (default: 0)'
+    )
+    
+    parser.add_argument(
+        '--no-alpha',
+        dest='parse_alpha',
+        action='store_false',
+        help='Skip parsing polarizability data'
+    )
+    
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='Enable verbose output'
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        # Run conversion
+        output_file = orca_to_extxyz(
+            args.input,
+            args.output,
+            args.charge,
+            args.parse_alpha,
+            args.verbose  
+        )
+        
+        print(f"Output file: {output_file}")
+        
+    except Exception as e:
+        print(f"Error during conversion: {e}", file=sys.stderr)
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)

--- a/emle/_tarball_to_extXYZ.py
+++ b/emle/_tarball_to_extXYZ.py
@@ -99,7 +99,7 @@ def orca_to_extxyz(
         if not (hasattr(parser, "mbis") and parser.mbis is not None):
             raise ValueError("MBIS data not available in parser")
 
-        # Core charges, chek if it's present and available for all frames
+        # Core charges, check if it's present and available for all frames
         if not ("q_core" in parser.mbis and len(parser.mbis["q_core"]) > i):
             raise ValueError(f"Core charges not available for frame {frame_number}")
         q_core = parser.mbis["q_core"][i]

--- a/emle/_tarball_to_extXYZ.py
+++ b/emle/_tarball_to_extXYZ.py
@@ -12,6 +12,7 @@ from ase import Atoms
 from ase.data import chemical_symbols
 
 from ._orca_parser import ORCAParser
+from ._units import _HARTREE_BOHR_TO_EV_A
 
 
 def orca_to_extxyz(
@@ -90,8 +91,9 @@ def orca_to_extxyz(
         # Create ASE atoms object from parser data
         atoms = Atoms(symbols=symbols, positions=parser.xyz[i])
 
-        # Add forces
-        atoms.arrays['forces_dft'] = parser.forces[i]
+        # Add forces (ORCAParser returns Hartree/Bohr; extXYZ stores eV/A
+        # for MACE training).
+        atoms.arrays['forces_dft'] = parser.forces[i] * _HARTREE_BOHR_TO_EV_A
 
         # Add MBIS properties
         if not (hasattr(parser, 'mbis') and parser.mbis is not None):

--- a/emle/_tarball_to_extXYZ.py
+++ b/emle/_tarball_to_extXYZ.py
@@ -1,5 +1,8 @@
 """Functions for converting ORCA tarball files to extXYZ format."""
 
+__author__ = "Laetitia Kantin"
+__email__ = "kantin@ibpc.fr"
+
 import sys
 from pathlib import Path
 
@@ -11,27 +14,40 @@ from ase.data import chemical_symbols
 from ._orca_parser import ORCAParser
 
 
-def orca_to_extxyz(orca_tarball_path, output_path=None, total_charge=0, 
-                   parse_alpha=True, verbose=False):
+def orca_to_extxyz(
+    orca_tarball_path,
+    output_path=None,
+    total_charge=0,
+    parse_alpha=True,
+    verbose=False,
+):
     """
     Convert ORCA tarball to extXYZ format using ORCAParser and ASE.
-    
-    Parameters:
-    -----------
-    orca_tarball_path : str or Path
-        Path to the ORCA tarball file
-    output_path : str or Path, optional
-        Output path for the extXYZ file. If None, uses input name with .xyz extension
-    total_charge : int, optional
-        Total charge of the system (default: 0)
-    parse_alpha : bool, optional
-        Whether to parse polarizability data (default: True)
-    verbose : bool, optional
-        Enable verbose output (default: False)
-    
-    Returns:
-    --------
-    str : Path to the created extXYZ file
+
+    Parameters
+    ----------
+
+    orca_tarball_path: str or Path
+        Path to the ORCA tarball file.
+
+    output_path: str or Path, optional
+        Output path for the extXYZ file. If None, uses the input name with a
+        '.xyz' extension.
+
+    total_charge: int
+        Total charge of the system (default: 0).
+
+    parse_alpha: bool
+        Whether to parse polarizability data (default: True).
+
+    verbose: bool
+        Enable verbose output (default: False).
+
+    Returns
+    -------
+
+    output_path: str
+        Path to the created extXYZ file.
     """
     orca_tarball_path = Path(orca_tarball_path)
     
@@ -151,7 +167,6 @@ def main():
     parser = argparse.ArgumentParser(
         description="Convert ORCA tarball files to extXYZ format",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="LK, 11/10/2025"
     )
     
     parser.add_argument(

--- a/emle/_tarball_to_extXYZ.py
+++ b/emle/_tarball_to_extXYZ.py
@@ -51,29 +51,29 @@ def orca_to_extxyz(
         Path to the created extXYZ file.
     """
     orca_tarball_path = Path(orca_tarball_path)
-    
+
     if not orca_tarball_path.exists():
         raise FileNotFoundError(f"ORCA tarball not found: {orca_tarball_path}")
-    
+
     # Set output path if not provided
     if output_path is None:
-        output_path = orca_tarball_path.with_suffix('.xyz')
+        output_path = orca_tarball_path.with_suffix(".xyz")
     else:
         output_path = Path(output_path)
-    
+
     if verbose:
         print(f"Parsing ORCA tarball: {orca_tarball_path}")
-    
+
     # Initialize ORCA parser
     parser = ORCAParser(str(orca_tarball_path), alpha=parse_alpha)
-    
+
     if verbose:
         print(f"Parser attributes: {list(parser.__dict__.keys())}")
-    
+
     # Get number of frames from parser data
-    if not (hasattr(parser, 'xyz') and parser.xyz is not None):
+    if not (hasattr(parser, "xyz") and parser.xyz is not None):
         raise ValueError("XYZ data not available in parser")
-    
+
     n_frames = len(parser.xyz)
     if verbose:
         print(f"Found {n_frames} frames")
@@ -84,140 +84,136 @@ def orca_to_extxyz(
 
     # Create atoms list
     atoms_list = []
-    
+
     for i in range(n_frames):
         frame_number = i + 1
-        
+
         # Create ASE atoms object from parser data
         atoms = Atoms(symbols=symbols, positions=parser.xyz[i])
 
         # Add forces (ORCAParser returns Hartree/Bohr; extXYZ stores eV/A
         # for MACE training).
-        atoms.arrays['forces_dft'] = parser.forces[i] * _HARTREE_BOHR_TO_EV_A
+        atoms.arrays["forces_dft"] = parser.forces[i] * _HARTREE_BOHR_TO_EV_A
 
         # Add MBIS properties
-        if not (hasattr(parser, 'mbis') and parser.mbis is not None):
+        if not (hasattr(parser, "mbis") and parser.mbis is not None):
             raise ValueError("MBIS data not available in parser")
-        
+
         # Core charges, chek if it's present and available for all frames
-        if not ('q_core' in parser.mbis and len(parser.mbis['q_core']) > i):
+        if not ("q_core" in parser.mbis and len(parser.mbis["q_core"]) > i):
             raise ValueError(f"Core charges not available for frame {frame_number}")
-        q_core = parser.mbis['q_core'][i]
-        
+        q_core = parser.mbis["q_core"][i]
+
         # Valence charges
-        if not ('q_val' in parser.mbis and len(parser.mbis['q_val']) > i):
+        if not ("q_val" in parser.mbis and len(parser.mbis["q_val"]) > i):
             raise ValueError(f"Valence charges not available for frame {frame_number}")
-        q_val = parser.mbis['q_val'][i]
-        
+        q_val = parser.mbis["q_val"][i]
+
         # Add q_core and q_val
-        atoms.arrays['q_core'] = q_core
-        atoms.arrays['q_val'] = q_val
+        atoms.arrays["q_core"] = q_core
+        atoms.arrays["q_val"] = q_val
 
         # Total charges
-        atoms.arrays['q'] = q_core + q_val
-        
+        atoms.arrays["q"] = q_core + q_val
+
         # Dipole moments (mu)
-        if not ('mu' in parser.mbis and len(parser.mbis['mu']) > i):
+        if not ("mu" in parser.mbis and len(parser.mbis["mu"]) > i):
             raise ValueError(f"Dipole moments not available for frame {frame_number}")
-        atoms.arrays['mu'] = parser.mbis['mu'][i]
-        
+        atoms.arrays["mu"] = parser.mbis["mu"][i]
+
         # Valence width (s)
-        if not ('s' in parser.mbis and len(parser.mbis['s']) > i):
+        if not ("s" in parser.mbis and len(parser.mbis["s"]) > i):
             raise ValueError(f"Valence width not available for frame {frame_number}")
-        atoms.arrays['s'] = parser.mbis['s'][i]
-        
-        # Add energy 
+        atoms.arrays["s"] = parser.mbis["s"][i]
+
+        # Add energy
         if parser.E_vac is None:
             raise ValueError(f"E_vac not available for frame {frame_number}")
 
-        # Set system properties 
-        atoms.info['pos_unit'] = 'angstrom'
-        atoms.info['energy_dft'] = parser.E_vac[i]
-        atoms.info['total_charge'] = total_charge
-        atoms.info['pbc'] = "F F F"
-              
+        # Set system properties
+        atoms.info["pos_unit"] = "angstrom"
+        atoms.info["energy_dft"] = parser.E_vac[i]
+        atoms.info["total_charge"] = total_charge
+        atoms.info["pbc"] = "F F F"
+
         # Add polarizability
         if parse_alpha:
-            if not (hasattr(parser, 'alpha') and parser.alpha is not None and len(parser.alpha) > i):
-                raise ValueError(f"Polarizability not available for frame {frame_number}")
-            
+            if not (
+                hasattr(parser, "alpha")
+                and parser.alpha is not None
+                and len(parser.alpha) > i
+            ):
+                raise ValueError(
+                    f"Polarizability not available for frame {frame_number}"
+                )
+
             alpha_tensor = parser.alpha[i]
             if isinstance(alpha_tensor, np.ndarray) and alpha_tensor.shape == (3, 3):
                 alpha_json = f"_JSON {alpha_tensor.tolist()}"
-                atoms.info['alpha'] = alpha_json
+                atoms.info["alpha"] = alpha_json
             else:
-                raise ValueError(f"Unexpected polarizability format for frame {frame_number}: {type(alpha_tensor)}, shape: {getattr(alpha_tensor, 'shape', 'N/A')}")
-        
+                raise ValueError(
+                    f"Unexpected polarizability format for frame {frame_number}: {type(alpha_tensor)}, shape: {getattr(alpha_tensor, 'shape', 'N/A')}"
+                )
+
         atoms_list.append(atoms)
-    
+
     if verbose:
         print(f"Writing extXYZ file: {output_path}")
-    
+
     # Write to extXYZ format
-    ase.io.write(str(output_path), atoms_list, format='extxyz')
-    
+    ase.io.write(str(output_path), atoms_list, format="extxyz")
+
     if verbose:
         print(f"Successfully created extXYZ file with {len(atoms_list)} frames")
-    
+
     return str(output_path)
 
 
 def main():
     """Command line interface for the ORCA tarball to extXYZ converter."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(
         description="Convert ORCA tarball files to extXYZ format",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
+
+    parser.add_argument("input", help="Input ORCA tarball file path")
+
     parser.add_argument(
-        'input',
-        help='Input ORCA tarball file path'
+        "-o", "--output", help="Output extXYZ file path (default: input_name.xyz)"
     )
-    
+
     parser.add_argument(
-        '-o', '--output',
-        help='Output extXYZ file path (default: input_name.xyz)'
+        "--charge", type=int, default=0, help="Total charge of the system (default: 0)"
     )
-    
+
     parser.add_argument(
-        '--charge',
-        type=int,
-        default=0,
-        help='Total charge of the system (default: 0)'
+        "--no-alpha",
+        dest="parse_alpha",
+        action="store_false",
+        help="Skip parsing polarizability data",
     )
-    
+
     parser.add_argument(
-        '--no-alpha',
-        dest='parse_alpha',
-        action='store_false',
-        help='Skip parsing polarizability data'
+        "-v", "--verbose", action="store_true", help="Enable verbose output"
     )
-    
-    parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        help='Enable verbose output'
-    )
-    
+
     args = parser.parse_args()
-    
+
     try:
         # Run conversion
         output_file = orca_to_extxyz(
-            args.input,
-            args.output,
-            args.charge,
-            args.parse_alpha,
-            args.verbose  
+            args.input, args.output, args.charge, args.parse_alpha, args.verbose
         )
-        
+
         print(f"Output file: {output_file}")
-        
+
     except Exception as e:
         print(f"Error during conversion: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc()
         sys.exit(1)

--- a/emle/_units.py
+++ b/emle/_units.py
@@ -32,3 +32,5 @@ _KCAL_MOL_TO_HARTREE = 1.0 / _ase.units.Hartree * _ase.units.kcal / _ase.units.m
 _HARTREE_TO_KCAL_MOL = _ase.units.Hartree / _ase.units.kcal * _ase.units.mol
 _HARTREE_TO_KJ_MOL = _ase.units.Hartree / _ase.units.kJ * _ase.units.mol
 _NANOMETER_TO_ANGSTROM = 10.0
+_HARTREE_BOHR_TO_EV_A = _ase.units.Hartree / _ase.units.Bohr
+

--- a/emle/_units.py
+++ b/emle/_units.py
@@ -33,4 +33,3 @@ _HARTREE_TO_KCAL_MOL = _ase.units.Hartree / _ase.units.kcal * _ase.units.mol
 _HARTREE_TO_KJ_MOL = _ase.units.Hartree / _ase.units.kJ * _ase.units.mol
 _NANOMETER_TO_ANGSTROM = 10.0
 _HARTREE_BOHR_TO_EV_A = _ase.units.Hartree / _ase.units.Bohr
-

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1445,7 +1445,7 @@ class EMLECalculator:
         # Reset the first step flag.
         self._is_first_step = not self._restart
 
-    def _sire_callback(self, atomic_numbers, charges_mm, xyz_qm, xyz_mm, idx_mm=None):
+    def _sire_callback(self, atomic_numbers, charges_mm, xyz_qm, xyz_mm, cell=None, idx_mm=None):
         """
         A callback function to be used with Sire.
 
@@ -1463,6 +1463,9 @@ class EMLECalculator:
 
         xyz_mm: [[float, float, float]]
             The coordinates of the MM atoms in Angstrom.
+
+        cell: [float]
+            PBC cell dimensions
 
         idx_mm: [int]
             A list of indices of the MM atoms in the QM/MM region.

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1138,7 +1138,7 @@ class EMLECalculator:
                 atoms.info['max_f_std'] = self._max_f_std
             if getattr(self._backends[0], "emle_values", None) is not None:
                 for key, value in self._backends[0].emle_values.items():
-                    atoms.arrays[key] = value.detach().cpu().numpy()
+                    atoms.arrays[key] = value[0].detach().cpu().numpy()
             _ase_io.write(self._qm_xyz_file, atoms, append=True)
 
             pc_data = _np.hstack((charges_mm[:, None], xyz_mm))

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -646,8 +646,11 @@ class EMLECalculator:
                     self._ani2x_model_index = ani2x_model_index
 
                 # Initialise the MACEMLE model.
-                elif backend == "mace":
-                    from .models import MACEEMLE as _MACEEMLE
+                elif backend in ["mace", "maceemle"]:
+                    if backend == "mace":
+                        from .models import MACEEMLE as _MACEEMLE
+                    else:
+                        from .models import MACEEMLEJoint as _MACEEMLE
 
                     mace_emle = _MACEEMLE(
                         emle_model=model,

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1133,8 +1133,9 @@ class EMLECalculator:
         # Write out the QM region to the xyz trajectory file.
         if self._qm_xyz_frequency > 0 and self._step % self._qm_xyz_frequency == 0:
             atoms = _ase.Atoms(positions=xyz_qm, numbers=atomic_numbers)
+            atoms.info['total_charge'] = charge
             if hasattr(self._backend, "_max_f_std"):
-                atoms.info = {"max_f_std": self._max_f_std}
+                atoms.info['max_f_std'] = self._max_f_std
             if getattr(self._backends[0], "emle_values", None) is not None:
                 for key, value in self._backends[0].emle_values.items():
                     atoms.arrays[key] = value.detach().cpu().numpy()

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1323,7 +1323,8 @@ class EMLECalculator:
 
                 grad_qm = grad_vac + dE_dxyz_qm.cpu().numpy() * _BOHR_TO_ANGSTROM
                 grad_mm = dE_dxyz_mm.cpu().numpy() * _BOHR_TO_ANGSTROM
-                E_tot = E_vac + E.sum().detach().cpu().numpy()
+                E_vac, E_static, E_induced = E.sum(axis=1).detach().cpu().numpy()
+                E_tot = E_vac + E_static + E_induced
 
             except Exception as e:
                 msg = f"Failed to compute {model} energies and gradients: {e}"

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1567,7 +1567,7 @@ class EMLECalculator:
                         f"{self._step:>10}{lam:22.12f}{E_tot:22.12f}{E_mm:22.12f}{E_emle:22.12f}\n"
                     )
                 else:
-                    f.write(f"{self._step:>10}{E_vac:22.12f}{E_tot:22.12self._backends[0].emle_valuesf}\n")
+                    f.write(f"{self._step:>10}{E_vac:22.12f}{E_tot:22.12f}\n")
 
         # Increment the step counter.
         if self._is_first_step:

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1135,6 +1135,9 @@ class EMLECalculator:
             atoms = _ase.Atoms(positions=xyz_qm, numbers=atomic_numbers)
             if hasattr(self._backend, "_max_f_std"):
                 atoms.info = {"max_f_std": self._max_f_std}
+            if getattr(self._backends[0], "emle_values", None) is not None:
+                for key, value in self._backends[0].emle_values.items():
+                    atoms.arrays[key] = value.detach().cpu().numpy()
             _ase_io.write(self._qm_xyz_file, atoms, append=True)
 
             pc_data = _np.hstack((charges_mm[:, None], xyz_mm))
@@ -1563,7 +1566,7 @@ class EMLECalculator:
                         f"{self._step:>10}{lam:22.12f}{E_tot:22.12f}{E_mm:22.12f}{E_emle:22.12f}\n"
                     )
                 else:
-                    f.write(f"{self._step:>10}{E_vac:22.12f}{E_tot:22.12f}\n")
+                    f.write(f"{self._step:>10}{E_vac:22.12f}{E_tot:22.12self._backends[0].emle_valuesf}\n")
 
         # Increment the step counter.
         if self._is_first_step:

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -1138,6 +1138,9 @@ class EMLECalculator:
                 atoms.info = {"max_f_std": self._backend._max_f_std}
             if getattr(self._backends[0], "emle_values", None) is not None:
                 for key, value in self._backends[0].emle_values.items():
+                    assert len(value) == 1, (
+                        "emle_values xyz export assumes a single frame per forward() call"
+                    )
                     atoms.arrays[key] = value[0].detach().cpu().numpy()
             _ase_io.write(self._qm_xyz_file, atoms, append=True)
 

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -513,8 +513,8 @@ class EMLECalculator:
 
         if use_dipoles:
             for backend in formatted_backends:
-                if backend != 'maceemle':
-                    msg = f"Static dipoles can only be used with maceemle backend"
+                if backend != 'emle-mace':
+                    msg = f"Static dipoles can only be used with emle-mace backend"
                     _logger.error(msg)
                     raise ValueError(msg)
 
@@ -660,7 +660,7 @@ class EMLECalculator:
                     self._ani2x_model_index = ani2x_model_index
 
                 # Initialise the MACEMLE model.
-                elif backend in ["mace", "maceemle"]:
+                elif backend in ["mace", "emle-mace"]:
                     if backend == "mace":
                         from .models import MACEEMLE as _MACEEMLE
                         mace_emle = _MACEEMLE(
@@ -673,7 +673,7 @@ class EMLECalculator:
                             atomic_numbers=atomic_numbers,
                             device=self._device,
                         )
-                    else:
+                    else:  # emle-mace
                         from .models import MACEEMLEJoint as _MACEEMLE
                         mace_emle = _MACEEMLE(
                             emle_model=model,

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -518,8 +518,7 @@ class EMLECalculator:
                     _logger.error(msg)
                     raise ValueError(msg)
 
-        self.use_dipoles = use_dipoles
-
+        self._use_dipoles = use_dipoles
 
         # Validate the external backend.
         if external_backend is not None:
@@ -678,8 +677,7 @@ class EMLECalculator:
                         mace_emle = _MACEEMLE(
                             emle_model=model,
                             emle_method=method,
-                            alpha_mode=alpha_mode,
-                            use_dipoles=self.use_dipoles,
+                            use_dipoles=self._use_dipoles,
                             mm_charges=self._mm_charges,
                             qm_charge=self._qm_charge,
                             mace_model=mace_model,

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -513,7 +513,7 @@ class EMLECalculator:
 
         if use_dipoles:
             for backend in formatted_backends:
-                if backend != 'emle-mace':
+                if backend != "emle-mace":
                     msg = f"Static dipoles can only be used with emle-mace backend"
                     _logger.error(msg)
                     raise ValueError(msg)
@@ -662,6 +662,7 @@ class EMLECalculator:
                 elif backend in ["mace", "emle-mace"]:
                     if backend == "mace":
                         from .models import MACEEMLE as _MACEEMLE
+
                         mace_emle = _MACEEMLE(
                             emle_model=model,
                             emle_method=method,
@@ -674,6 +675,7 @@ class EMLECalculator:
                         )
                     else:  # emle-mace
                         from .models import MACEEMLEJoint as _MACEEMLE
+
                         mace_emle = _MACEEMLE(
                             emle_model=model,
                             emle_method=method,
@@ -1133,14 +1135,14 @@ class EMLECalculator:
         # Write out the QM region to the xyz trajectory file.
         if self._qm_xyz_frequency > 0 and self._step % self._qm_xyz_frequency == 0:
             atoms = _ase.Atoms(positions=xyz_qm, numbers=atomic_numbers)
-            atoms.info['total_charge'] = charge
+            atoms.info["total_charge"] = charge
             if hasattr(self._backend, "_max_f_std"):
                 atoms.info = {"max_f_std": self._backend._max_f_std}
             if getattr(self._backends[0], "emle_values", None) is not None:
                 for key, value in self._backends[0].emle_values.items():
-                    assert len(value) == 1, (
-                        "emle_values xyz export assumes a single frame per forward() call"
-                    )
+                    assert (
+                        len(value) == 1
+                    ), "emle_values xyz export assumes a single frame per forward() call"
                     atoms.arrays[key] = value[0].detach().cpu().numpy()
             _ase_io.write(self._qm_xyz_file, atoms, append=True)
 
@@ -1580,7 +1582,7 @@ class EMLECalculator:
                 xyz_qm,
                 xyz_mm,
                 cell=cell,
-                charge=self._qm_charge
+                charge=self._qm_charge,
             )
         )
 

--- a/emle/models/__init__.py
+++ b/emle/models/__init__.py
@@ -28,4 +28,4 @@ from ._emle_aev_computer import EMLEAEVComputer
 from ._emle_base import EMLEBase
 from ._emle import EMLE
 from ._ani import ANI2xEMLE
-from ._mace import MACEEMLE
+from ._mace import MACEEMLE, MACEEMLEJoint

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -490,6 +490,7 @@ class EMLE(_torch.nn.Module):
             s = external_params['s']
             q_core = external_params['q_core']
             q_val = external_params['q_val']
+            mu = external_params.get('mu')
 
             xyz_qm_bohr = self._xyz_qm * ANGSTROM_TO_BOHR
             mask = atomic_numbers > 0
@@ -507,6 +508,7 @@ class EMLE(_torch.nn.Module):
                 self._xyz_qm,
                 qm_charge,
             )
+            mu = None
 
         # Convert coordinates to Bohr.
         xyz_qm_bohr = self._xyz_qm * ANGSTROM_TO_BOHR
@@ -528,7 +530,7 @@ class EMLE(_torch.nn.Module):
                 q_core, dtype=self._charges_mm.dtype, device=self._device
             )
         E_static = self._emle_base.get_static_energy(
-            q_core, q_val, self._charges_mm, mesh_data
+            q_core, q_val, self._charges_mm, mesh_data, mu
         )
 
         # Compute the induced energy.

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -521,21 +521,21 @@ class EMLE(_torch.nn.Module):
         # These are returned as batched tensors, so we need to extract the
         # first element of each.
         if external_params is not None:
-            s = external_params['s']
-            q_core = external_params['q_core']
-            q_val = external_params['q_val']
-            mu = external_params.get('mu')
+            s = external_params["s"]
+            q_core = external_params["q_core"]
+            q_val = external_params["q_val"]
+            mu = external_params.get("mu")
 
             xyz_qm_bohr = self._xyz_qm * ANGSTROM_TO_BOHR
             mask = atomic_numbers > 0
 
             species_id = self._emle_base._species_map[atomic_numbers]
-            k = external_params['k_Z'][species_id]
+            k = external_params["k_Z"][species_id]
 
             r_data = self._emle_base._get_r_data(xyz_qm_bohr, mask)
-            A_thole = self._emle_base._get_A_thole(r_data, s, q_val,
-                                                   k,
-                                                   external_params['a_Thole'])
+            A_thole = self._emle_base._get_A_thole(
+                r_data, s, q_val, k, external_params["a_Thole"]
+            )
         else:
             s, q_core, q_val, A_thole = self._emle_base(
                 self._atomic_numbers,

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -32,7 +32,6 @@ import os as _os
 import scipy.io as _scipy_io
 import torch as _torch
 import torchani as _torchani
-from emle.models import EMLEBase
 
 from torch import Tensor
 from typing import Union, Optional, Dict
@@ -445,6 +444,29 @@ class EMLE(_torch.nn.Module):
 
         qm_charge: int or torch.Tensor (BATCH,)
             The charge on the QM region.
+
+        external_params: Optional[Dict[str, torch.Tensor]]
+            Pre-computed EMLE parameters supplied by an external model (for
+            example MACEEMLEJoint, where MACE predicts these quantities). When
+            provided, they replace the values that EMLEBase would otherwise
+            predict internally. Required keys and shapes:
+
+                's': torch.Tensor (1, N_QM_ATOMS)
+                    Valence widths.
+                'q_core': torch.Tensor (1, N_QM_ATOMS)
+                    Core charges.
+                'q_val': torch.Tensor (1, N_QM_ATOMS)
+                    Valence charges.
+                'a_Thole': torch.Tensor (scalar)
+                    Thole damping parameter.
+                'k_Z': torch.Tensor (N_SPECIES,)
+                    Per-species alpha/volume ratios.
+                'mu': Optional[torch.Tensor] (1, N_QM_ATOMS, 3)
+                    Static atomic dipoles (optional; included in the static
+                    energy when present).
+
+            When None, 's', 'q_core', 'q_val', and the Thole tensor are
+            predicted by EMLEBase (original behaviour).
 
         Returns
         -------

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -32,7 +32,7 @@ import numpy as _np
 import torch as _torch
 
 from torch import Tensor
-from typing import Tuple
+from typing import Tuple, Optional
 
 import torchani as _torchani
 
@@ -790,6 +790,7 @@ class EMLEBase(_torch.nn.Module):
         q_val: Tensor,
         charges_mm: Tensor,
         mesh_data: Tuple[Tensor, Tensor, Tensor],
+        mu: Optional[Tensor] = None
     ) -> Tensor:
         """
         Calculate the static electrostatic energy.
@@ -809,6 +810,12 @@ class EMLEBase(_torch.nn.Module):
         mesh_data: mesh_data object (output of self._get_mesh_data)
             Mesh data object.
 
+        q_val: torch.Tensor (N_BATCH, N_QM_ATOMS,)
+            QM valence charges.
+
+        mu: Optional[torch.Tensor] (N_BATCH, N_QM_ATOMS,)
+            QM static atomic dipoles.
+
         Returns
         -------
 
@@ -819,6 +826,9 @@ class EMLEBase(_torch.nn.Module):
         vpot_q_core = EMLEBase._get_vpot_q(q_core, mesh_data[0])
         vpot_q_val = EMLEBase._get_vpot_q(q_val, mesh_data[1])
         vpot_static = vpot_q_core + vpot_q_val
+        if mu is not None:
+            vpot_mu = EMLEBase._get_vpot_mu(mu, mesh_data[2])
+            vpot_static += vpot_mu
         return _torch.sum(vpot_static * charges_mm, dim=1)
 
     @staticmethod

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -791,7 +791,7 @@ class EMLEBase(_torch.nn.Module):
         q_val: Tensor,
         charges_mm: Tensor,
         mesh_data: Tuple[Tensor, Tensor, Tensor],
-        mu: Optional[Tensor] = None
+        mu: Optional[Tensor] = None,
     ) -> Tensor:
         """
         Calculate the static electrostatic energy.

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -811,10 +811,7 @@ class EMLEBase(_torch.nn.Module):
         mesh_data: mesh_data object (output of self._get_mesh_data)
             Mesh data object.
 
-        q_val: torch.Tensor (N_BATCH, N_QM_ATOMS,)
-            QM valence charges.
-
-        mu: Optional[torch.Tensor] (N_BATCH, N_QM_ATOMS,)
+        mu: Optional[torch.Tensor] (N_BATCH, N_QM_ATOMS, 3)
             QM static atomic dipoles.
 
         Returns

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -769,6 +769,10 @@ class MACEEMLEJoint(_torch.nn.Module):
         self._E_vac_qbc = _torch.empty(0, dtype=self._dtype)
         self._grads_qbc = _torch.empty(0, dtype=self._dtype)
 
+        self.emle_values = {'s': _torch.empty(0, dtype=self._dtype),
+                            'q_core': _torch.empty(0, dtype=self._dtype),
+                            'q': _torch.empty(0, dtype=self._dtype)}
+
         # Create the z_table of the MACE model.
         self._z_table = [int(z.item()) for z in self._mace.atomic_numbers]
         self._r_max = self._mace.r_max.item()
@@ -1109,6 +1113,9 @@ class MACEEMLEJoint(_torch.nn.Module):
             assert q_core is not None
             assert q is not None
             assert mu is not None
+
+            # Store to be included in qm.xyz
+            self.emle_values.update({'s': s, 'q_core': q_core, 'q': q})
 
             s = s.view(1, -1)
             q_core = q_core.view(1, -1)

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -771,7 +771,8 @@ class MACEEMLEJoint(_torch.nn.Module):
 
         self.emle_values = {'s': _torch.empty(0, dtype=self._dtype),
                             'q_core': _torch.empty(0, dtype=self._dtype),
-                            'q': _torch.empty(0, dtype=self._dtype)}
+                            'q': _torch.empty(0, dtype=self._dtype),
+                            'mu': _torch.empty(0, dtype=self._dtype)}
 
         # Create the z_table of the MACE model.
         self._z_table = [int(z.item()) for z in self._mace.atomic_numbers]
@@ -1115,7 +1116,7 @@ class MACEEMLEJoint(_torch.nn.Module):
             assert mu is not None
 
             # Store to be included in qm.xyz
-            self.emle_values.update({'s': s, 'q_core': q_core, 'q': q})
+            self.emle_values.update({'s': s, 'q_core': q_core, 'q': q, 'mu': mu})
 
             s = s.view(1, -1)
             q_core = q_core.view(1, -1)

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -25,7 +25,7 @@
 __author__ = "Joao Morado"
 __email__ = "joaomorado@gmail.com"
 
-__all__ = ["MACEEMLE"]
+__all__ = ["MACEEMLE", "MACEEMLEJoint"]
 
 import os as _os
 import torch as _torch
@@ -586,6 +586,572 @@ class MACEEMLE(_torch.nn.Module):
                 # Get the EMLE energy components.
                 E_emle = self._emle(
                     atomic_numbers, charges_mm, xyz_qm, xyz_mm, qm_charge
+                )
+                results_E_emle_static[i] = E_emle[0][0]
+                results_E_emle_induced[i] = E_emle[1][0]
+
+        # Return the MACE and EMLE energy components.
+        return _torch.stack(
+            [results_E_vac, results_E_emle_static, results_E_emle_induced]
+        )
+
+
+class MACEEMLEJoint(_torch.nn.Module):
+    """
+    Combined MACE and EMLE model. Predicts the in vacuo MACE energy along with
+    static and induced EMLE energy components from a single MACE EqGNN.
+    """
+
+    # Class attributes.
+
+    # A flag for type inference. TorchScript doesn't support inheritance, so
+    # we need to check for an object of type torch.nn.Module, and that it has
+    # the required _is_emle attribute.
+    _is_emle = True
+
+    def __init__(
+            self,
+            emle_model=None,
+            emle_method="electrostatic",
+            alpha_mode="species", # Ignored, to be implemented
+            mm_charges=None,
+            qm_charge=0,
+            mace_model=None,
+            atomic_numbers=None,
+            device=None,
+            dtype=None,
+    ):
+        """
+        Constructor.
+
+        Parameters
+        ----------
+
+        emle_model: str
+            Path to a custom EMLE model parameter file. If None, then the
+            default model for the specified 'alpha_mode' will be used.
+
+        emle_method: str
+            The desired embedding method. Options are:
+                "electrostatic":
+                    Full ML electrostatic embedding.
+                "mechanical":
+                    ML predicted charges for the core, but zero valence charge.
+                "nonpol":
+                    Non-polarisable ML embedding. Here the induced component of
+                    the potential is zeroed.
+                "mm":
+                    MM charges are used for the core charge and valence charges
+                    are set to zero.
+
+        alpha_mode: str
+            How atomic polarizabilities are calculated.
+                "species":
+                    one volume scaling factor is used for each species
+                "reference":
+                    scaling factors are obtained with GPR using the values learned
+                    for each reference environmentw
+
+        mm_charges: List[float], Tuple[Float], numpy.ndarray, torch.Tensor
+            List of MM charges for atoms in the QM region in units of mod
+            electron charge. This is required if the 'mm' method is specified.
+
+        qm_charge: int
+            The charge on the QM region. This can also be passed when calling
+            the forward method. The non-default value will take precendence.
+
+        mace_model: List[str], Tuple[str], str
+            Name of the MACE model(s) to use.
+            Available pre-trained models are 'mace-off23-small', 'mace-off23-medium', 'mace-off23-large'.
+            To use a locally trained MACE model, provide the path to the model file.
+            If None, the MACE-OFF23(S) model will be used by default.
+            If more than one model is provided, only the energy from the first model will be returned
+            in the forward pass, but the energy and forces from all models will be stored.
+
+        atomic_numbers: List[int], Tuple[int], numpy.ndarray, torch.Tensor (N_ATOMS,)
+            List of atomic numbers to use in the MACE model.
+
+        device: torch.device
+            The device on which to run the model.
+
+        dtype: torch.dtype
+            The data type to use for the models floating point tensors.
+        """
+
+        # Call the base class constructor.
+        super().__init__()
+
+        if not _has_mace:
+            raise ImportError(
+                'mace is required to use the MACEEMLE model. Install it with "pip install mace-torch"'
+            )
+        if not _has_e3nn:
+            raise ImportError("e3nn is required to compile the MACEmodel.")
+        if not _has_nnpops:
+            raise ImportError("NNPOps is required to use the MACEEMLE model.")
+
+        if device is not None:
+            if not isinstance(device, _torch.device):
+                raise TypeError("'device' must be of type 'torch.device'")
+        else:
+            device = _torch.get_default_device()
+
+        if dtype is not None:
+            if not isinstance(dtype, _torch.dtype):
+                raise TypeError("'dtype' must be of type 'torch.dtype'")
+        else:
+            self._dtype = _torch.get_default_dtype()
+
+        if atomic_numbers is not None:
+            if isinstance(atomic_numbers, _np.ndarray):
+                atomic_numbers = atomic_numbers.tolist()
+            if isinstance(atomic_numbers, (list, tuple)):
+                if not all(isinstance(i, int) for i in atomic_numbers):
+                    raise ValueError("'atomic_numbers' must be a list of integers")
+                else:
+                    atomic_numbers = _torch.tensor(
+                        atomic_numbers, dtype=_torch.int64, device=device
+                    )
+            if not isinstance(atomic_numbers, _torch.Tensor):
+                raise TypeError("'atomic_numbers' must be of type 'torch.Tensor'")
+            # Check that they are integers.
+            if atomic_numbers.dtype != _torch.int64:
+                raise ValueError("'atomic_numbers' must be of dtype 'torch.int64'")
+            self.register_buffer("_atomic_numbers", atomic_numbers.to(device))
+        else:
+            self.register_buffer(
+                "_atomic_numbers",
+                _torch.tensor(
+                    [], dtype=_torch.int64, device=device, requires_grad=False
+                ),
+            )
+
+        # Create an instance of the EMLE model.
+        self._emle = _EMLE(
+            model=emle_model,
+            method=emle_method,
+            alpha_mode=alpha_mode,
+            atomic_numbers=(atomic_numbers if atomic_numbers is not None else None),
+            mm_charges=mm_charges,
+            qm_charge=qm_charge,
+            device=device,
+            dtype=dtype,
+            create_aev_calculator=True,
+        )
+
+        if not isinstance(mace_model, (list, tuple)):
+            mace_model = [mace_model] if mace_model is None or isinstance(mace_model, str) else None
+
+        if mace_model is None or any(not isinstance(i, (str, type(None))) for i in mace_model):
+            raise TypeError("'mace_model' must be a list, tuple, or str, with elements of type str or None")
+
+        from mace.tools.scripts_utils import extract_config_mace_model
+        self._mace_models = _torch.nn.ModuleList()
+        for model in mace_model:
+            source_model = self._load_mace_model(model, device)
+
+            # Extract the config from the model.
+            config = extract_config_mace_model(source_model)
+
+            # Create the target model.
+            target_model = source_model.__class__(**config).to(device)
+
+            # Load the state dict.
+            target_model.load_state_dict(source_model.state_dict(), strict=False)
+
+            # Compile the model.
+            self._mace_models.append(_e3nn_jit.compile(target_model).to(self._dtype))
+
+        # Set the MACE model to the first model.
+        self._mace = self._mace_models[0]
+
+        self._E_vac_qbc = _torch.empty(0, dtype=self._dtype)
+        self._grads_qbc = _torch.empty(0, dtype=self._dtype)
+
+        # Create the z_table of the MACE model.
+        self._z_table = [int(z.item()) for z in self._mace.atomic_numbers]
+        self._r_max = self._mace.r_max.item()
+
+        if len(self._atomic_numbers) > 0:
+            # Get the node attributes.
+            node_attrs = self._get_node_attrs(self._atomic_numbers)
+            self.register_buffer("_node_attrs", node_attrs.to(self._dtype))
+            self.register_buffer(
+                "_ptr",
+                _torch.tensor(
+                    [0, node_attrs.shape[0]], dtype=_torch.long, requires_grad=False
+                ),
+            )
+            self.register_buffer(
+                "_batch",
+                _torch.zeros(
+                    node_attrs.shape[0], dtype=_torch.long, requires_grad=False
+                ),
+            )
+        else:
+            # Initialise the node attributes.
+            self.register_buffer("_node_attrs", _torch.tensor([], dtype=self._dtype))
+            self.register_buffer(
+                "_ptr", _torch.tensor([], dtype=_torch.long, requires_grad=False)
+            )
+            self.register_buffer(
+                "_batch", _torch.tensor([], dtype=_torch.long, requires_grad=False)
+            )
+
+        # No PBCs for now.
+        self.register_buffer(
+            "_pbc",
+            _torch.tensor(
+                [False, False, False], dtype=_torch.bool, requires_grad=False
+            ),
+        )
+        self.register_buffer(
+            "_cell", _torch.zeros((3, 3), dtype=self._dtype, requires_grad=False)
+        )
+
+        # Set the _get_neighbor_pairs method on the instance.
+        self._get_neighbor_pairs = _get_neighbor_pairs
+
+    @staticmethod
+    def _load_mace_model(mace_model: str, device: _torch.device):
+        """
+        Load a MACE model.
+
+        Parameters
+        ----------
+        mace_model: str
+            Path to the MACE model file or the name of the pre-trained MACE model.
+        device: torch.device
+            Device on which to load the model.
+
+        Returns
+        -------
+        source_model: torch.nn.Module
+            The MACE model.
+        """
+        # Load the MACE model.
+        if mace_model is not None:
+            if not isinstance(mace_model, str):
+                raise TypeError("'mace_model' must be of type 'str'")
+            # Convert to lower case and remove whitespace.
+            formatted_mace_model = mace_model.lower().replace(" ", "")
+            if formatted_mace_model.startswith("mace-off23"):
+                size = formatted_mace_model.split("-")[-1]
+                if not size in ["small", "medium", "large"]:
+                    raise ValueError(
+                        f"Unsupported MACE model: '{mace_model}'. Available MACE-OFF23 models are "
+                        "'mace-off23-small', 'mace-off23-medium', 'mace-off23-large'"
+                    )
+                source_model = _mace_off(
+                    model=size, device=device, return_raw_model=True
+                )
+            else:
+                # Assuming that the model is a local model.
+                if _os.path.exists(mace_model):
+                    source_model = _torch.load(mace_model, map_location=device)
+                else:
+                    raise FileNotFoundError(f"MACE model file not found: {mace_model}")
+        else:
+            # If no MACE model is provided, use the default MACE-OFF23(S) model.
+            source_model = _mace_off(
+                model="small", device=device, return_raw_model=True
+            )
+
+        return source_model
+
+    @staticmethod
+    def _to_one_hot(indices: _torch.Tensor, num_classes: int) -> _torch.Tensor:
+        """
+        Convert a tensor of indices to one-hot encoding.
+
+        Parameters
+        ----------
+
+        indices: torch.Tensor
+            Tensor of indices.
+
+        num_classes: int
+            Number of classes of atomic numbers.
+
+        Returns
+        -------
+
+        oh: torch.Tensor
+            One-hot encoding of the indices.
+        """
+        shape = indices.shape[:-1] + (num_classes,)
+        oh = _torch.zeros(shape, device=indices.device).view(shape)
+        return oh.scatter_(dim=-1, index=indices, value=1)
+
+    @staticmethod
+    def _atomic_numbers_to_indices(
+            atomic_numbers: _torch.Tensor, z_table: List[int]
+    ) -> _torch.Tensor:
+        """
+        Get the indices of the atomic numbers in the z_table.
+
+        Parameters
+        ----------
+
+        atomic_numbers: torch.Tensor (N_ATOMS,)
+            Atomic numbers of QM atoms.
+
+        z_table: List[int]
+            List of atomic numbers in the MACE model.
+
+        Returns
+        -------
+
+        indices: torch.Tensor (N_ATOMS, 1)
+            Indices of the atomic numbers in the z_table.
+        """
+        return _torch.tensor(
+            [z_table.index(z) for z in atomic_numbers], dtype=_torch.long
+        ).unsqueeze(-1)
+
+    def _get_node_attrs(self, atomic_numbers: _torch.Tensor) -> _torch.Tensor:
+        """
+        Internal method to get the node attributes for the MACE model.
+
+        Parameters
+        ----------
+
+        atomic_numbers: torch.Tensor (N_ATOMS,)
+            Atomic numbers of QM atoms.
+
+        Returns
+        -------
+
+        node_attrs: torch.Tensor (N_ATOMS, N_FEATURES)
+            Node attributes for the MACE model.
+        """
+        ids = self._atomic_numbers_to_indices(atomic_numbers, z_table=self._z_table)
+        return self._to_one_hot(ids, num_classes=len(self._z_table))
+
+    def to(self, *args, **kwargs):
+        """
+        Performs Tensor dtype and/or device conversion on the model.
+        """
+        self._emle = self._emle.to(*args, **kwargs)
+        self._mace = self._mace.to(*args, **kwargs)
+        self._mace_models = _torch.nn.ModuleList([
+            model.to(*args, **kwargs) for model in self._mace_models
+        ])
+        return self
+
+    def cpu(self, **kwargs):
+        """
+        Move all model parameters and buffers to CPU memory.
+        """
+        self._emle = self._emle.cpu(**kwargs)
+        self._mace = self._mace.cpu(**kwargs)
+        if self._atomic_numbers is not None:
+            self._atomic_numbers = self._atomic_numbers.cpu(**kwargs)
+        self._mace_models = _torch.nn.ModuleList([
+            model.cpu(**kwargs) for model in self._mace_models
+        ])
+        return self
+
+    def cuda(self, **kwargs):
+        """
+        Move all model parameters and buffers to CUDA memory.
+        """
+        self._emle = self._emle.cuda(**kwargs)
+        self._mace = self._mace.cuda(**kwargs)
+        if self._atomic_numbers is not None:
+            self._atomic_numbers = self._atomic_numbers.cuda(**kwargs)
+        self._mace_models = _torch.nn.ModuleList([
+            model.cuda(**kwargs) for model in self._mace_models
+        ])
+        return self
+
+    def double(self):
+        """
+        Cast all floating point model parameters and buffers to float64 precision.
+        """
+        self._emle = self._emle.double()
+        self._mace = self._mace.double()
+        self._mace_models = _torch.nn.ModuleList([
+            model.double() for model in self._mace_models
+        ])
+        return self
+
+    def float(self):
+        """
+        Cast all floating point model parameters and buffers to float32 precision.
+        """
+        self._emle = self._emle.float()
+        self._mace = self._mace.float()
+        self._mace_models = _torch.nn.ModuleList([
+            model.float() for model in self._mace_models
+        ])
+        return self
+
+    def forward(
+            self,
+            atomic_numbers: Tensor,
+            charges_mm: Tensor,
+            xyz_qm: Tensor,
+            xyz_mm: Tensor,
+            qm_charge: int = 0,
+    ) -> Tensor:
+        """
+        Compute the the MACE and static and induced EMLE energy components.
+
+        Parameters
+        ----------
+
+        atomic_numbers: torch.Tensor (N_QM_ATOMS,) or (BATCH, N_QM_ATOMS)
+            Atomic numbers of QM atoms.
+
+        charges_mm: torch.Tensor (max_mm_atoms,) or (BATCH, max_mm_atoms)
+            MM point charges in atomic units.
+
+        xyz_qm: torch.Tensor (N_QM_ATOMS, 3), or (BATCH, N_QM_ATOMS, 3)
+            Positions of QM atoms in Angstrom.
+
+        xyz_mm: torch.Tensor (N_MM_ATOMS, 3) or (BATCH, N_MM_ATOMS, 3)
+            Positions of MM atoms in Angstrom.
+
+        qm_charge: int
+            The charge on the QM region.
+
+        Returns
+        -------
+
+        result: torch.Tensor (3,)
+            The ANI2x and static and induced EMLE energy components in Hartree.
+        """
+        # Get the device.
+        device = xyz_qm.device
+
+        # Batch the inputs if necessary.
+        if atomic_numbers.ndim == 1:
+            atomic_numbers = atomic_numbers.unsqueeze(0)
+            xyz_qm = xyz_qm.unsqueeze(0)
+            xyz_mm = xyz_mm.unsqueeze(0)
+            charges_mm = charges_mm.unsqueeze(0)
+
+        # Store the number of batches.
+        num_batches = atomic_numbers.shape[0]
+
+        # Store the number of models.
+        num_models = len(self._mace_models)
+
+        # Create tensors to store the data for QbC.
+        self._E_vac_qbc = _torch.empty(num_models, num_batches, dtype=self._dtype, device=device)
+        self._grads_qbc = _torch.empty(num_models, num_batches, xyz_qm.shape[1], 3, dtype=self._dtype, device=device)
+
+        # Create tensors to store the results.
+        results_E_vac = _torch.empty(num_batches, dtype=self._dtype, device=device)
+        results_E_emle_static = _torch.empty(
+            num_batches, dtype=self._dtype, device=device
+        )
+        results_E_emle_induced = _torch.empty(
+            num_batches, dtype=self._dtype, device=device
+        )
+
+        # Loop over the batches.
+        for i in range(num_batches):
+            # Get the edge index and shifts for this configuration.
+            edge_index, shifts = self._get_neighbor_pairs(
+                xyz_qm[i], None, self._r_max, self._dtype, device
+            )
+
+            if not _torch.equal(atomic_numbers[i], self._atomic_numbers):
+                # Update the node attributes if the atomic numbers have changed.
+                self._node_attrs = (
+                    self._get_node_attrs(atomic_numbers[i]).to(self._dtype).to(device)
+                )
+                self._ptr = _torch.tensor(
+                    [0, self._node_attrs.shape[0]],
+                    dtype=_torch.long,
+                    requires_grad=False,
+                ).to(device)
+                self._batch = _torch.zeros(
+                    self._node_attrs.shape[0], dtype=_torch.long
+                ).to(device)
+                self._atomic_numbers = atomic_numbers[i]
+
+            # Get the in vacuo energy.
+            EV_TO_HARTREE = 0.0367492929
+
+            positions = xyz_qm[i].to(self._dtype)
+
+            # Create the input dictionary
+            input_dict = {
+                "ptr": self._ptr,
+                "node_attrs": self._node_attrs,
+                "batch": self._batch,
+                "head": _torch.zeros(1, dtype=_torch.int).to(device),
+                "pbc": self._pbc,
+                "positions": positions,
+                "edge_index": edge_index,
+                "shifts": shifts,
+                "cell": self._cell,
+                "total_charge": _torch.tensor(qm_charge, dtype=self._dtype).to(device)
+            }
+
+            # Here, instead of just getting the energy, store the output and get all the params. Then
+            # pass them to EMLE with "use_external_props".
+            output = self._mace(input_dict, compute_force=False)
+
+            E_vac = output["interaction_energy"]
+            s = output["valence_widths"]
+            q_core = output["core_charges"]
+            q = output["charges"]
+
+            assert s is not None
+            assert q_core is not None
+            assert q is not None
+
+            s = s.view(1, -1)
+            q_core = q_core.view(1, -1)
+            q = q.view(1, -1)
+            q_val = q - q_core
+            # mu = output["atomic_dipoles"]
+
+            assert (
+                    E_vac is not None
+            ), "The model did not return any energy. Please check the input."
+
+            results_E_vac[i] = E_vac[0] * EV_TO_HARTREE
+
+            # Decouple the positions from the computation graph for the next models.
+            input_dict["positions"] = input_dict["positions"].clone().detach().requires_grad_(True)
+
+            # Do inference for the other models.
+            if len(self._mace_models) > 1:
+                for j, mace in enumerate(self._mace_models):
+                    E_vac_qbc = mace(input_dict, compute_force=False)["interaction_energy"]
+
+                    assert (
+                            E_vac_qbc is not None
+                    ), "The model did not return any energy. Please check the input."
+
+                    # Calculate the gradients
+                    grads_qbc = _torch.autograd.grad([E_vac_qbc], [input_dict["positions"]])[0]
+                    assert grads_qbc is not None, "Gradient computation failed"
+
+                    # Store the results.
+                    self._E_vac_qbc[j, i] = E_vac_qbc[0] * EV_TO_HARTREE
+                    self._grads_qbc[j, i] = grads_qbc * EV_TO_HARTREE
+
+            # If there are no point charges, return the in vacuo energy and zeros
+            # for the static and induced terms.
+            if len(xyz_mm[i]) == 0:
+                zero = _torch.tensor(0.0, dtype=xyz_qm.dtype, device=device)
+                results_E_emle_static[i] = zero
+                results_E_emle_induced[i] = zero
+            else:
+                external_params = {'s': s,
+                                   'q_core': q_core,
+                                   'q_val': q_val,
+                                   'a_Thole': self._mace.a_Thole,
+                                   'k_Z': self._mace.elements_alpha_v_ratios}
+                # Get the EMLE energy components.
+                E_emle = self._emle(
+                    atomic_numbers, charges_mm, xyz_qm, xyz_mm, qm_charge, external_params
                 )
                 results_E_emle_static[i] = E_emle[0][0]
                 results_E_emle_induced[i] = E_emle[1][0]

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -1193,6 +1193,10 @@ class MACEEMLEJoint(_torch.nn.Module):
         # Store the number of models.
         num_models = len(self._mace_models)
 
+        # Fixed model parameters, pulled out of the per-batch loop.
+        a_Thole = self._mace.a_Thole
+        k_Z = self._mace.elements_alpha_v_ratios
+
         # Create tensors to store the data for QbC.
         self._E_vac_qbc = _torch.empty(
             num_models, num_batches, dtype=self._dtype, device=device
@@ -1324,11 +1328,13 @@ class MACEEMLEJoint(_torch.nn.Module):
                 results_E_emle_static[i] = zero
                 results_E_emle_induced[i] = zero
             else:
-                external_params = {'s': s,
-                                   'q_core': q_core,
-                                   'q_val': q_val,
-                                   'a_Thole': self._mace.a_Thole,
-                                   'k_Z': self._mace.elements_alpha_v_ratios}
+                external_params = {
+                    's': s,
+                    'q_core': q_core,
+                    'q_val': q_val,
+                    'a_Thole': a_Thole,
+                    'k_Z': k_Z,
+                }
                 if mu is not None:
                     external_params['mu'] = mu
                 # Get the EMLE energy components. Pass only batch element i so

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -69,7 +69,9 @@ try:
     if not hasattr(_mace_models_module, "EnergyEMLEMACE"):
         _mace_models_module.EnergyEMLEMACE = EnergyEMLEMACE
 except Exception:
-    pass  # emle-mace not installed; torch.load() will fail for EnergyEMLEMACE checkpoints
+    # emle-mace not installed; torch.load() will fail for EnergyEMLEMACE checkpoints
+    pass
+
 
 def _is_energy_emle_mace(model) -> bool:
     # TorchScript-compiled models expose the source class name via
@@ -251,7 +253,9 @@ class MACEEMLE(_torch.nn.Module):
             # Dispatch to the appropriate config extractor.
             if _is_energy_emle_mace(source_model):
                 try:
-                    from emle_mace.tools.model_utils import extract_config_emle_mace_model
+                    from emle_mace.tools.model_utils import (
+                        extract_config_emle_mace_model,
+                    )
                     config = extract_config_emle_mace_model(source_model)
                 except ImportError as e:
                     raise ImportError(
@@ -541,8 +545,8 @@ class MACEEMLE(_torch.nn.Module):
         Returns
         -------
 
-        result: torch.Tensor (3,)
-            The ANI2x and static and induced EMLE energy components in Hartree.
+        result: torch.Tensor (3,) or (3, BATCH)
+            The MACE and static and induced EMLE energy components in Hartree.
         """
         # Get the device.
         device = xyz_qm.device
@@ -714,8 +718,8 @@ class MACEEMLEJoint(_torch.nn.Module):
         ----------
 
         emle_model: str
-            Path to a custom EMLE model parameter file. If None, then the
-            default model for the specified 'alpha_mode' will be used.
+            Path to a custom EMLE model parameter file. If None, the default
+            model will be used.
 
         emle_method: str
             The desired embedding method. Options are:
@@ -756,6 +760,12 @@ class MACEEMLEJoint(_torch.nn.Module):
 
         atomic_numbers: List[int], Tuple[int], numpy.ndarray, torch.Tensor (N_ATOMS,)
             List of atomic numbers to use in the MACE model.
+
+        use_dipoles: bool
+            Whether to include the MACE-predicted atomic dipoles 'mu' in the
+            static electrostatic energy. When True, 'mu' is passed to EMLE as
+            part of the external parameters. The calculator only permits this
+            flag with the 'emle-mace' backend.
 
         device: torch.device
             The device on which to run the model.
@@ -826,10 +836,19 @@ class MACEEMLEJoint(_torch.nn.Module):
         )
 
         if not isinstance(mace_model, (list, tuple)):
-            mace_model = [mace_model] if mace_model is None or isinstance(mace_model, str) else None
+            mace_model = (
+                [mace_model]
+                if mace_model is None or isinstance(mace_model, str)
+                else None
+            )
 
-        if mace_model is None or any(not isinstance(i, (str, type(None))) for i in mace_model):
-            raise TypeError("'mace_model' must be a list, tuple, or str, with elements of type str or None")
+        if mace_model is None or any(
+            not isinstance(i, (str, type(None))) for i in mace_model
+        ):
+            raise TypeError(
+                "'mace_model' must be a list, tuple, or str, with elements "
+                "of type str or None"
+            )
 
         from mace.tools.scripts_utils import extract_config_mace_model
         self._mace_models = _torch.nn.ModuleList()
@@ -846,7 +865,9 @@ class MACEEMLEJoint(_torch.nn.Module):
             # Dispatch to the appropriate config extractor.
             if _is_energy_emle_mace(source_model):
                 try:
-                    from emle_mace.tools.model_utils import extract_config_emle_mace_model
+                    from emle_mace.tools.model_utils import (
+                        extract_config_emle_mace_model,
+                    )
                     config = extract_config_emle_mace_model(source_model)
                 except ImportError as e:
                     raise ImportError(
@@ -1007,7 +1028,7 @@ class MACEEMLEJoint(_torch.nn.Module):
 
     @staticmethod
     def _atomic_numbers_to_indices(
-            atomic_numbers: _torch.Tensor, z_table: List[int]
+        atomic_numbers: _torch.Tensor, z_table: List[int]
     ) -> _torch.Tensor:
         """
         Get the indices of the atomic numbers in the z_table.
@@ -1056,9 +1077,9 @@ class MACEEMLEJoint(_torch.nn.Module):
         """
         self._emle = self._emle.to(*args, **kwargs)
         self._mace = self._mace.to(*args, **kwargs)
-        self._mace_models = _torch.nn.ModuleList([
-            model.to(*args, **kwargs) for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.to(*args, **kwargs) for model in self._mace_models]
+        )
         return self
 
     def cpu(self, **kwargs):
@@ -1069,9 +1090,9 @@ class MACEEMLEJoint(_torch.nn.Module):
         self._mace = self._mace.cpu(**kwargs)
         if self._atomic_numbers is not None:
             self._atomic_numbers = self._atomic_numbers.cpu(**kwargs)
-        self._mace_models = _torch.nn.ModuleList([
-            model.cpu(**kwargs) for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.cpu(**kwargs) for model in self._mace_models]
+        )
         return self
 
     def cuda(self, **kwargs):
@@ -1082,9 +1103,9 @@ class MACEEMLEJoint(_torch.nn.Module):
         self._mace = self._mace.cuda(**kwargs)
         if self._atomic_numbers is not None:
             self._atomic_numbers = self._atomic_numbers.cuda(**kwargs)
-        self._mace_models = _torch.nn.ModuleList([
-            model.cuda(**kwargs) for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.cuda(**kwargs) for model in self._mace_models]
+        )
         return self
 
     def double(self):
@@ -1093,9 +1114,9 @@ class MACEEMLEJoint(_torch.nn.Module):
         """
         self._emle = self._emle.double()
         self._mace = self._mace.double()
-        self._mace_models = _torch.nn.ModuleList([
-            model.double() for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.double() for model in self._mace_models]
+        )
         return self
 
     def float(self):
@@ -1104,22 +1125,22 @@ class MACEEMLEJoint(_torch.nn.Module):
         """
         self._emle = self._emle.float()
         self._mace = self._mace.float()
-        self._mace_models = _torch.nn.ModuleList([
-            model.float() for model in self._mace_models
-        ])
+        self._mace_models = _torch.nn.ModuleList(
+            [model.float() for model in self._mace_models]
+        )
         return self
 
     def forward(
-            self,
-            atomic_numbers: Tensor,
-            charges_mm: Tensor,
-            xyz_qm: Tensor,
-            xyz_mm: Tensor,
-            cell: Optional[Tensor] = None,
-            qm_charge: int = 0,
+        self,
+        atomic_numbers: Tensor,
+        charges_mm: Tensor,
+        xyz_qm: Tensor,
+        xyz_mm: Tensor,
+        cell: Optional[Tensor] = None,
+        qm_charge: int = 0,
     ) -> Tensor:
         """
-        Compute the the MACE and static and induced EMLE energy components.
+        Compute the MACE and static and induced EMLE energy components.
 
         Parameters
         ----------
@@ -1145,8 +1166,8 @@ class MACEEMLEJoint(_torch.nn.Module):
         Returns
         -------
 
-        result: torch.Tensor (3,)
-            The ANI2x and static and induced EMLE energy components in Hartree.
+        result: torch.Tensor (3,) or (3, BATCH)
+            The MACE and static and induced EMLE energy components in Hartree.
         """
         # Get the device.
         device = xyz_qm.device
@@ -1169,8 +1190,17 @@ class MACEEMLEJoint(_torch.nn.Module):
         num_models = len(self._mace_models)
 
         # Create tensors to store the data for QbC.
-        self._E_vac_qbc = _torch.empty(num_models, num_batches, dtype=self._dtype, device=device)
-        self._grads_qbc = _torch.empty(num_models, num_batches, xyz_qm.shape[1], 3, dtype=self._dtype, device=device)
+        self._E_vac_qbc = _torch.empty(
+            num_models, num_batches, dtype=self._dtype, device=device
+        )
+        self._grads_qbc = _torch.empty(
+            num_models,
+            num_batches,
+            xyz_qm.shape[1],
+            3,
+            dtype=self._dtype,
+            device=device,
+        )
 
         # Create tensors to store the results.
         results_E_vac = _torch.empty(num_batches, dtype=self._dtype, device=device)
@@ -1223,11 +1253,10 @@ class MACEEMLEJoint(_torch.nn.Module):
                 "edge_index": edge_index,
                 "shifts": shifts,
                 "cell": self._cell if cell is None else cell,
-                "total_charge": _torch.tensor(qm_charge, dtype=self._dtype).to(device)
+                "total_charge": _torch.tensor(qm_charge, dtype=self._dtype).to(device),
             }
 
-            # Here, instead of just getting the energy, store the output and get all the params. Then
-            # pass them to EMLE with "use_external_props".
+            # Run MACE once, reusing its output to feed EMLE via external_params.
             output = self._mace(input_dict, compute_force=False)
 
             E_vac = output["interaction_energy"]
@@ -1242,6 +1271,8 @@ class MACEEMLEJoint(_torch.nn.Module):
             assert mu is not None
 
             # Store to be included in qm.xyz
+            # Store per-batch-element tensors so the calculator can write them
+            # into the QM xyz trajectory. Keys match EMLE.forward conventions.
             self.emle_values['s'].append(s)
             self.emle_values['q_core'].append(q_core)
             self.emle_values['q'].append(q)
@@ -1254,25 +1285,31 @@ class MACEEMLEJoint(_torch.nn.Module):
             mu = mu.view(1, -1, 3) if self.use_dipoles else None
 
             assert (
-                    E_vac is not None
+                E_vac is not None
             ), "The model did not return any energy. Please check the input."
 
             results_E_vac[i] = E_vac[0] * EV_TO_HARTREE
 
             # Decouple the positions from the computation graph for the next models.
-            input_dict["positions"] = input_dict["positions"].clone().detach().requires_grad_(True)
+            input_dict["positions"] = (
+                input_dict["positions"].clone().detach().requires_grad_(True)
+            )
 
             # Do inference for the other models.
             if len(self._mace_models) > 1:
                 for j, mace in enumerate(self._mace_models):
-                    E_vac_qbc = mace(input_dict, compute_force=False)["interaction_energy"]
+                    E_vac_qbc = mace(input_dict, compute_force=False)[
+                        "interaction_energy"
+                    ]
 
                     assert (
-                            E_vac_qbc is not None
+                        E_vac_qbc is not None
                     ), "The model did not return any energy. Please check the input."
 
                     # Calculate the gradients
-                    grads_qbc = _torch.autograd.grad([E_vac_qbc], [input_dict["positions"]])[0]
+                    grads_qbc = _torch.autograd.grad(
+                        [E_vac_qbc], [input_dict["positions"]]
+                    )[0]
                     assert grads_qbc is not None, "Gradient computation failed"
 
                     # Store the results.
@@ -1311,6 +1348,14 @@ class MACEEMLEJoint(_torch.nn.Module):
         )
 
     def reset_emle(self) -> None:
+        """
+        Clear the per-frame EMLE output buffers.
+
+        Called at the start of each forward() so emle_values exposes only the
+        quantities produced by the current call (one tensor per batch element,
+        per key). The calculator reads these values to write QM xyz trajectory
+        frames; see emle/calculator.py.
+        """
         self.emle_values['s'] = []
         self.emle_values['q_core'] = []
         self.emle_values['q'] = []

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -1289,9 +1289,13 @@ class MACEEMLEJoint(_torch.nn.Module):
                                    'k_Z': self._mace.elements_alpha_v_ratios}
                 if mu is not None:
                     external_params['mu'] = mu
-                # Get the EMLE energy components.
+                # Get the EMLE energy components. Pass only batch element i so
+                # that external_params (batch=1) and the coordinate tensors are
+                # consistent inside EMLE's forward.
                 E_emle = self._emle(
-                    atomic_numbers, charges_mm, xyz_qm, xyz_mm, cell, qm_charge,
+                    atomic_numbers[i:i+1], charges_mm[i:i+1],
+                    xyz_qm[i:i+1], xyz_mm[i:i+1],
+                    cell, qm_charge,
                     external_params
                 )
                 results_E_emle_static[i] = E_emle[0][0]

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -706,17 +706,16 @@ class MACEEMLEJoint(_torch.nn.Module):
     _is_emle = True
 
     def __init__(
-            self,
-            emle_model=None,
-            emle_method="electrostatic",
-            alpha_mode="species", # Ignored, to be implemented
-            mm_charges=None,
-            qm_charge=0,
-            mace_model=None,
-            atomic_numbers=None,
-            use_dipoles=False,
-            device=None,
-            dtype=None,
+        self,
+        emle_model=None,
+        emle_method="electrostatic",
+        mm_charges=None,
+        qm_charge=0,
+        mace_model=None,
+        atomic_numbers=None,
+        use_dipoles=False,
+        device=None,
+        dtype=None,
     ):
         """
         Constructor.
@@ -740,14 +739,6 @@ class MACEEMLEJoint(_torch.nn.Module):
                 "mm":
                     MM charges are used for the core charge and valence charges
                     are set to zero.
-
-        alpha_mode: str
-            How atomic polarizabilities are calculated.
-                "species":
-                    one volume scaling factor is used for each species
-                "reference":
-                    scaling factors are obtained with GPR using the values learned
-                    for each reference environmentw
 
         mm_charges: List[float], Tuple[Float], numpy.ndarray, torch.Tensor
             List of MM charges for atoms in the QM region in units of mod
@@ -830,10 +821,13 @@ class MACEEMLEJoint(_torch.nn.Module):
             )
 
         # Create an instance of the EMLE model.
+        # alpha_mode is fixed to "species" here: MACEEMLEJoint currently only
+        # supports the species mode. Re-expose as a parameter once reference
+        # mode is wired through MACE.
         self._emle = _EMLE(
             model=emle_model,
             method=emle_method,
-            alpha_mode=alpha_mode,
+            alpha_mode="species",
             atomic_numbers=(atomic_numbers if atomic_numbers is not None else None),
             mm_charges=mm_charges,
             qm_charge=qm_charge,

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -235,8 +235,15 @@ class MACEEMLE(_torch.nn.Module):
         for model in mace_model:
             source_model = self._load_mace_model(model, device)
 
+            # Already-compiled models (RecursiveScriptModule) cannot have their
+            # config extracted via attribute introspection (ModuleList indexing
+            # is not supported).  Reuse them directly after dtype conversion.
+            if source_model.__class__.__name__ == "RecursiveScriptModule":
+                self._mace_models.append(source_model.to(self._dtype))
+                continue
+
             # Dispatch to the appropriate config extractor.
-            if source_model.__class__.__name__ == "EnergyEMLEMACE":
+            if getattr(source_model, "original_name", source_model.__class__.__name__) == "EnergyEMLEMACE":
                 try:
                     from emle_mace.tools.model_utils import extract_config_emle_mace_model
                     config = extract_config_emle_mace_model(source_model)
@@ -252,7 +259,13 @@ class MACEEMLE(_torch.nn.Module):
                 raise ValueError(f"Failed to extract model config: {config['error']}")
 
             # Create the target model.
-            target_model = source_model.__class__(**config).to(device)
+            _source_name = getattr(source_model, "original_name", source_model.__class__.__name__)
+            if _source_name == "EnergyEMLEMACE":
+                from emle_mace.models import EnergyEMLEMACE as _EnergyEMLEMACE
+                _model_cls = _EnergyEMLEMACE
+            else:
+                _model_cls = source_model.__class__
+            target_model = _model_cls(**config).to(device)
 
             # Load the state dict.
             target_model.load_state_dict(source_model.state_dict(), strict=False)
@@ -818,8 +831,15 @@ class MACEEMLEJoint(_torch.nn.Module):
         for model in mace_model:
             source_model = self._load_mace_model(model, device)
 
+            # Already-compiled models (RecursiveScriptModule) cannot have their
+            # config extracted via attribute introspection (ModuleList indexing
+            # is not supported).  Reuse them directly after dtype conversion.
+            if source_model.__class__.__name__ == "RecursiveScriptModule":
+                self._mace_models.append(source_model.to(self._dtype))
+                continue
+
             # Dispatch to the appropriate config extractor.
-            if source_model.__class__.__name__ == "EnergyEMLEMACE":
+            if getattr(source_model, "original_name", source_model.__class__.__name__) == "EnergyEMLEMACE":
                 try:
                     from emle_mace.tools.model_utils import extract_config_emle_mace_model
                     config = extract_config_emle_mace_model(source_model)
@@ -835,7 +855,13 @@ class MACEEMLEJoint(_torch.nn.Module):
                 raise ValueError(f"Failed to extract model config: {config['error']}")
 
             # Create the target model.
-            target_model = source_model.__class__(**config).to(device)
+            _source_name = getattr(source_model, "original_name", source_model.__class__.__name__)
+            if _source_name == "EnergyEMLEMACE":
+                from emle_mace.models import EnergyEMLEMACE as _EnergyEMLEMACE
+                _model_cls = _EnergyEMLEMACE
+            else:
+                _model_cls = source_model.__class__
+            target_model = _model_cls(**config).to(device)
 
             # Load the state dict.
             target_model.load_state_dict(source_model.state_dict(), strict=False)

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -340,7 +340,9 @@ class MACEEMLE(_torch.nn.Module):
             else:
                 # Assuming that the model is a local model.
                 if _os.path.exists(mace_model):
-                    source_model = _torch.load(mace_model, map_location=device)
+                    source_model = _torch.load(
+                        mace_model, map_location=device, weights_only=False
+                    )
                 else:
                     raise FileNotFoundError(f"MACE model file not found: {mace_model}")
         else:
@@ -930,7 +932,9 @@ class MACEEMLEJoint(_torch.nn.Module):
             else:
                 # Assuming that the model is a local model.
                 if _os.path.exists(mace_model):
-                    source_model = _torch.load(mace_model, map_location=device)
+                    source_model = _torch.load(
+                        mace_model, map_location=device, weights_only=False
+                    )
                 else:
                     raise FileNotFoundError(f"MACE model file not found: {mace_model}")
         else:

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -53,6 +53,13 @@ try:
 except:
     _has_e3nn = False
 
+# Re-export EnergyEMLEMACE so that torch.load() can deserialize saved models
+# without requiring user code to import emle_mace directly.
+try:
+    from emle_mace.models import EnergyEMLEMACE as EnergyEMLEMACE  # noqa: F401
+except ImportError:
+    pass  # emle-mace not installed; torch.load() will fail if the checkpoint uses EnergyEMLEMACE
+
 
 class MACEEMLE(_torch.nn.Module):
     """
@@ -217,8 +224,21 @@ class MACEEMLE(_torch.nn.Module):
         for model in mace_model:
             source_model = self._load_mace_model(model, device)
 
-            # Extract the config from the model.
-            config = extract_config_mace_model(source_model)
+            # Dispatch to the appropriate config extractor.
+            if source_model.__class__.__name__ == "EnergyEMLEMACE":
+                try:
+                    from emle_mace.tools.model_utils import extract_config_emle_mace_model
+                    config = extract_config_emle_mace_model(source_model)
+                except ImportError as e:
+                    raise ImportError(
+                        "emle-mace package is required to load EnergyEMLEMACE models. "
+                        "Install it with: pip install emle-mace"
+                    ) from e
+            else:
+                config = extract_config_mace_model(source_model)
+
+            if "error" in config:
+                raise ValueError(f"Failed to extract model config: {config['error']}")
 
             # Create the target model.
             target_model = source_model.__class__(**config).to(device)
@@ -785,8 +805,21 @@ class MACEEMLEJoint(_torch.nn.Module):
         for model in mace_model:
             source_model = self._load_mace_model(model, device)
 
-            # Extract the config from the model.
-            config = extract_config_mace_model(source_model)
+            # Dispatch to the appropriate config extractor.
+            if source_model.__class__.__name__ == "EnergyEMLEMACE":
+                try:
+                    from emle_mace.tools.model_utils import extract_config_emle_mace_model
+                    config = extract_config_emle_mace_model(source_model)
+                except ImportError as e:
+                    raise ImportError(
+                        "emle-mace package is required to load EnergyEMLEMACE models. "
+                        "Install it with: pip install emle-mace"
+                    ) from e
+            else:
+                config = extract_config_mace_model(source_model)
+
+            if "error" in config:
+                raise ValueError(f"Failed to extract model config: {config['error']}")
 
             # Create the target model.
             target_model = source_model.__class__(**config).to(device)

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -71,6 +71,12 @@ try:
 except Exception:
     pass  # emle-mace not installed; torch.load() will fail for EnergyEMLEMACE checkpoints
 
+def _is_energy_emle_mace(model) -> bool:
+    # TorchScript-compiled models expose the source class name via
+    # 'original_name'; plain nn.Modules expose it via __class__.__name__.
+    name = getattr(model, "original_name", model.__class__.__name__)
+    return name == "EnergyEMLEMACE"
+
 
 class MACEEMLE(_torch.nn.Module):
     """
@@ -243,7 +249,7 @@ class MACEEMLE(_torch.nn.Module):
                 continue
 
             # Dispatch to the appropriate config extractor.
-            if getattr(source_model, "original_name", source_model.__class__.__name__) == "EnergyEMLEMACE":
+            if _is_energy_emle_mace(source_model):
                 try:
                     from emle_mace.tools.model_utils import extract_config_emle_mace_model
                     config = extract_config_emle_mace_model(source_model)
@@ -259,8 +265,7 @@ class MACEEMLE(_torch.nn.Module):
                 raise ValueError(f"Failed to extract model config: {config['error']}")
 
             # Create the target model.
-            _source_name = getattr(source_model, "original_name", source_model.__class__.__name__)
-            if _source_name == "EnergyEMLEMACE":
+            if _is_energy_emle_mace(source_model):
                 from emle_mace.models import EnergyEMLEMACE as _EnergyEMLEMACE
                 _model_cls = _EnergyEMLEMACE
             else:
@@ -839,7 +844,7 @@ class MACEEMLEJoint(_torch.nn.Module):
                 continue
 
             # Dispatch to the appropriate config extractor.
-            if getattr(source_model, "original_name", source_model.__class__.__name__) == "EnergyEMLEMACE":
+            if _is_energy_emle_mace(source_model):
                 try:
                     from emle_mace.tools.model_utils import extract_config_emle_mace_model
                     config = extract_config_emle_mace_model(source_model)
@@ -855,8 +860,7 @@ class MACEEMLEJoint(_torch.nn.Module):
                 raise ValueError(f"Failed to extract model config: {config['error']}")
 
             # Create the target model.
-            _source_name = getattr(source_model, "original_name", source_model.__class__.__name__)
-            if _source_name == "EnergyEMLEMACE":
+            if _is_energy_emle_mace(source_model):
                 from emle_mace.models import EnergyEMLEMACE as _EnergyEMLEMACE
                 _model_cls = _EnergyEMLEMACE
             else:

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -57,12 +57,18 @@ except:
 # deserialize saved EnergyEMLEMACE checkpoints.  Pickle records the class at
 # its original location (mace.modules.models.EnergyEMLEMACE); we restore that
 # binding here without modifying the mace package itself.
+#
+# e3nn loads constants.pt at import time via torch.load.  Under PyTorch >= 2.6
+# the default weights_only=True rejects the slice object stored in that file.
+# Allow slice globally so that e3nn (and therefore emle_mace) can be imported
+# without requiring the TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD environment variable.
 try:
+    _torch.serialization.add_safe_globals([slice])
     from emle_mace.models import EnergyEMLEMACE as EnergyEMLEMACE  # noqa: F401
     import mace.modules.models as _mace_models_module
     if not hasattr(_mace_models_module, "EnergyEMLEMACE"):
         _mace_models_module.EnergyEMLEMACE = EnergyEMLEMACE
-except ImportError:
+except Exception:
     pass  # emle-mace not installed; torch.load() will fail for EnergyEMLEMACE checkpoints
 
 

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -1341,10 +1341,13 @@ class MACEEMLEJoint(_torch.nn.Module):
                 # that external_params (batch=1) and the coordinate tensors are
                 # consistent inside EMLE's forward.
                 E_emle = self._emle(
-                    atomic_numbers[i:i+1], charges_mm[i:i+1],
-                    xyz_qm[i:i+1], xyz_mm[i:i+1],
-                    cell, qm_charge,
-                    external_params
+                    atomic_numbers[i:i + 1],
+                    charges_mm[i:i + 1],
+                    xyz_qm[i:i + 1],
+                    xyz_mm[i:i + 1],
+                    cell,
+                    qm_charge,
+                    external_params,
                 )
                 results_E_emle_static[i] = E_emle[0][0]
                 results_E_emle_induced[i] = E_emle[1][0]

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -901,9 +901,23 @@ class MACEEMLEJoint(_torch.nn.Module):
         self._E_vac_qbc = _torch.empty(0, dtype=self._dtype)
         self._grads_qbc = _torch.empty(0, dtype=self._dtype)
 
+        # Per-batch-element EMLE quantities predicted by the MACE model,
+        # exposed here so the EMLECalculator can write them into the QM xyz
+        # trajectory (see emle/calculator.py) and the EMLEAnalyzer can
+        # recompute polarisabilities / energies from them. Keys:
+        #   's'      - valence widths
+        #   'q_core' - core charges
+        #   'q_val'  - valence charges (= total MACE charges minus q_core);
+        #              name matches EMLE.forward's `external_params`
+        #   'q'      - total charges (= q_core + q_val); kept for parity with
+        #              the training-data extXYZ produced by tarball-to-extxyz
+        #   'mu'     - static atomic dipoles (3-vectors)
+        # Cleared by reset_emle() at the start of each forward() call, then
+        # one tensor is appended per batch element inside forward().
         self.emle_values: Dict[str, List[Tensor]] = {
             's': [_torch.empty(0, dtype=self._dtype)],
             'q_core': [_torch.empty(0, dtype=self._dtype)],
+            'q_val': [_torch.empty(0, dtype=self._dtype)],
             'q': [_torch.empty(0, dtype=self._dtype)],
             'mu': [_torch.empty(0, dtype=self._dtype)],
         }
@@ -1275,18 +1289,21 @@ class MACEEMLEJoint(_torch.nn.Module):
             assert q is not None
             assert mu is not None
 
-            # Store to be included in qm.xyz
+            q_val = q - q_core
+
             # Store per-batch-element tensors so the calculator can write them
-            # into the QM xyz trajectory. Keys match EMLE.forward conventions.
+            # into the QM xyz trajectory. Both q_val (EMLE.forward convention)
+            # and q (total, for parity with the training-data extXYZ written
+            # by tarball-to-extxyz) are stored.
             self.emle_values['s'].append(s)
             self.emle_values['q_core'].append(q_core)
+            self.emle_values['q_val'].append(q_val)
             self.emle_values['q'].append(q)
             self.emle_values['mu'].append(mu)
 
             s = s.view(1, -1)
             q_core = q_core.view(1, -1)
-            q = q.view(1, -1)
-            q_val = q - q_core
+            q_val = q_val.view(1, -1)
             mu = mu.view(1, -1, 3) if self.use_dipoles else None
 
             assert (
@@ -1368,5 +1385,6 @@ class MACEEMLEJoint(_torch.nn.Module):
         """
         self.emle_values['s'] = []
         self.emle_values['q_core'] = []
+        self.emle_values['q_val'] = []
         self.emle_values['q'] = []
         self.emle_values['mu'] = []

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -53,12 +53,17 @@ try:
 except:
     _has_e3nn = False
 
-# Re-export EnergyEMLEMACE so that torch.load() can deserialize saved models
-# without requiring user code to import emle_mace directly.
+# Inject EnergyEMLEMACE into mace.modules.models so that torch.load() can
+# deserialize saved EnergyEMLEMACE checkpoints.  Pickle records the class at
+# its original location (mace.modules.models.EnergyEMLEMACE); we restore that
+# binding here without modifying the mace package itself.
 try:
     from emle_mace.models import EnergyEMLEMACE as EnergyEMLEMACE  # noqa: F401
+    import mace.modules.models as _mace_models_module
+    if not hasattr(_mace_models_module, "EnergyEMLEMACE"):
+        _mace_models_module.EnergyEMLEMACE = EnergyEMLEMACE
 except ImportError:
-    pass  # emle-mace not installed; torch.load() will fail if the checkpoint uses EnergyEMLEMACE
+    pass  # emle-mace not installed; torch.load() will fail for EnergyEMLEMACE checkpoints
 
 
 class MACEEMLE(_torch.nn.Module):

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -66,6 +66,7 @@ try:
     _torch.serialization.add_safe_globals([slice])
     from emle_mace.models import EnergyEMLEMACE as EnergyEMLEMACE  # noqa: F401
     import mace.modules.models as _mace_models_module
+
     if not hasattr(_mace_models_module, "EnergyEMLEMACE"):
         _mace_models_module.EnergyEMLEMACE = EnergyEMLEMACE
 except Exception:
@@ -256,6 +257,7 @@ class MACEEMLE(_torch.nn.Module):
                     from emle_mace.tools.model_utils import (
                         extract_config_emle_mace_model,
                     )
+
                     config = extract_config_emle_mace_model(source_model)
                 except ImportError as e:
                     raise ImportError(
@@ -271,6 +273,7 @@ class MACEEMLE(_torch.nn.Module):
             # Create the target model.
             if _is_energy_emle_mace(source_model):
                 from emle_mace.models import EnergyEMLEMACE as _EnergyEMLEMACE
+
                 _model_cls = _EnergyEMLEMACE
             else:
                 _model_cls = source_model.__class__
@@ -676,10 +679,10 @@ class MACEEMLE(_torch.nn.Module):
                 # that the coordinate tensors inside EMLE.forward are batch=1
                 # and consistent with the per-element loop here.
                 E_emle = self._emle(
-                    atomic_numbers[i:i + 1],
-                    charges_mm[i:i + 1],
-                    xyz_qm[i:i + 1],
-                    xyz_mm[i:i + 1],
+                    atomic_numbers[i : i + 1],
+                    charges_mm[i : i + 1],
+                    xyz_qm[i : i + 1],
+                    xyz_mm[i : i + 1],
                     cell,
                     qm_charge,
                 )
@@ -852,6 +855,7 @@ class MACEEMLEJoint(_torch.nn.Module):
             )
 
         from mace.tools.scripts_utils import extract_config_mace_model
+
         self._mace_models = _torch.nn.ModuleList()
         for model in mace_model:
             source_model = self._load_mace_model(model, device)
@@ -869,6 +873,7 @@ class MACEEMLEJoint(_torch.nn.Module):
                     from emle_mace.tools.model_utils import (
                         extract_config_emle_mace_model,
                     )
+
                     config = extract_config_emle_mace_model(source_model)
                 except ImportError as e:
                     raise ImportError(
@@ -884,6 +889,7 @@ class MACEEMLEJoint(_torch.nn.Module):
             # Create the target model.
             if _is_energy_emle_mace(source_model):
                 from emle_mace.models import EnergyEMLEMACE as _EnergyEMLEMACE
+
                 _model_cls = _EnergyEMLEMACE
             else:
                 _model_cls = source_model.__class__
@@ -915,11 +921,11 @@ class MACEEMLEJoint(_torch.nn.Module):
         # Cleared by reset_emle() at the start of each forward() call, then
         # one tensor is appended per batch element inside forward().
         self.emle_values: Dict[str, List[Tensor]] = {
-            's': [_torch.empty(0, dtype=self._dtype)],
-            'q_core': [_torch.empty(0, dtype=self._dtype)],
-            'q_val': [_torch.empty(0, dtype=self._dtype)],
-            'q': [_torch.empty(0, dtype=self._dtype)],
-            'mu': [_torch.empty(0, dtype=self._dtype)],
+            "s": [_torch.empty(0, dtype=self._dtype)],
+            "q_core": [_torch.empty(0, dtype=self._dtype)],
+            "q_val": [_torch.empty(0, dtype=self._dtype)],
+            "q": [_torch.empty(0, dtype=self._dtype)],
+            "mu": [_torch.empty(0, dtype=self._dtype)],
         }
 
         # Create the z_table of the MACE model.
@@ -1295,11 +1301,11 @@ class MACEEMLEJoint(_torch.nn.Module):
             # into the QM xyz trajectory. Both q_val (EMLE.forward convention)
             # and q (total, for parity with the training-data extXYZ written
             # by tarball-to-extxyz) are stored.
-            self.emle_values['s'].append(s)
-            self.emle_values['q_core'].append(q_core)
-            self.emle_values['q_val'].append(q_val)
-            self.emle_values['q'].append(q)
-            self.emle_values['mu'].append(mu)
+            self.emle_values["s"].append(s)
+            self.emle_values["q_core"].append(q_core)
+            self.emle_values["q_val"].append(q_val)
+            self.emle_values["q"].append(q)
+            self.emle_values["mu"].append(mu)
 
             s = s.view(1, -1)
             q_core = q_core.view(1, -1)
@@ -1346,22 +1352,22 @@ class MACEEMLEJoint(_torch.nn.Module):
                 results_E_emle_induced[i] = zero
             else:
                 external_params = {
-                    's': s,
-                    'q_core': q_core,
-                    'q_val': q_val,
-                    'a_Thole': a_Thole,
-                    'k_Z': k_Z,
+                    "s": s,
+                    "q_core": q_core,
+                    "q_val": q_val,
+                    "a_Thole": a_Thole,
+                    "k_Z": k_Z,
                 }
                 if mu is not None:
-                    external_params['mu'] = mu
+                    external_params["mu"] = mu
                 # Get the EMLE energy components. Pass only batch element i so
                 # that external_params (batch=1) and the coordinate tensors are
                 # consistent inside EMLE's forward.
                 E_emle = self._emle(
-                    atomic_numbers[i:i + 1],
-                    charges_mm[i:i + 1],
-                    xyz_qm[i:i + 1],
-                    xyz_mm[i:i + 1],
+                    atomic_numbers[i : i + 1],
+                    charges_mm[i : i + 1],
+                    xyz_qm[i : i + 1],
+                    xyz_mm[i : i + 1],
                     cell,
                     qm_charge,
                     external_params,
@@ -1383,8 +1389,8 @@ class MACEEMLEJoint(_torch.nn.Module):
         per key). The calculator reads these values to write QM xyz trajectory
         frames; see emle/calculator.py.
         """
-        self.emle_values['s'] = []
-        self.emle_values['q_core'] = []
-        self.emle_values['q_val'] = []
-        self.emle_values['q'] = []
-        self.emle_values['mu'] = []
+        self.emle_values["s"] = []
+        self.emle_values["q_core"] = []
+        self.emle_values["q_val"] = []
+        self.emle_values["q"] = []
+        self.emle_values["mu"] = []

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -548,6 +548,9 @@ class MACEEMLE(_torch.nn.Module):
         result: torch.Tensor (3,) or (3, BATCH)
             The MACE and static and induced EMLE energy components in Hartree.
         """
+        # TorchScript requires constants to be local variables.
+        EV_TO_HARTREE = 0.0367492929
+
         # Get the device.
         device = xyz_qm.device
 
@@ -613,9 +616,6 @@ class MACEEMLE(_torch.nn.Module):
                     self._node_attrs.shape[0], dtype=_torch.long
                 ).to(device)
                 self._atomic_numbers = atomic_numbers[i]
-
-            # Get the in vacuo energy.
-            EV_TO_HARTREE = 0.0367492929
 
             positions = xyz_qm[i].to(self._dtype)
 
@@ -1169,6 +1169,9 @@ class MACEEMLEJoint(_torch.nn.Module):
         result: torch.Tensor (3,) or (3, BATCH)
             The MACE and static and induced EMLE energy components in Hartree.
         """
+        # TorchScript requires constants to be local variables.
+        EV_TO_HARTREE = 0.0367492929
+
         # Get the device.
         device = xyz_qm.device
 
@@ -1236,9 +1239,6 @@ class MACEEMLEJoint(_torch.nn.Module):
                     self._node_attrs.shape[0], dtype=_torch.long
                 ).to(device)
                 self._atomic_numbers = atomic_numbers[i]
-
-            # Get the in vacuo energy.
-            EV_TO_HARTREE = 0.0367492929
 
             positions = xyz_qm[i].to(self._dtype)
 

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -672,9 +672,16 @@ class MACEEMLE(_torch.nn.Module):
                 results_E_emle_static[i] = zero
                 results_E_emle_induced[i] = zero
             else:
-                # Get the EMLE energy components.
+                # Get the EMLE energy components. Pass only batch element i so
+                # that the coordinate tensors inside EMLE.forward are batch=1
+                # and consistent with the per-element loop here.
                 E_emle = self._emle(
-                    atomic_numbers, charges_mm, xyz_qm, xyz_mm, cell, qm_charge
+                    atomic_numbers[i:i + 1],
+                    charges_mm[i:i + 1],
+                    xyz_qm[i:i + 1],
+                    xyz_mm[i:i + 1],
+                    cell,
+                    qm_charge,
                 )
                 results_E_emle_static[i] = E_emle[0][0]
                 results_E_emle_induced[i] = E_emle[1][0]

--- a/emle/train/_trainer.py
+++ b/emle/train/_trainer.py
@@ -699,7 +699,7 @@ class EMLETrainer:
         if train_thole:
             plot_data.update(
                 {
-                    "alpha_species": self._thole_loss._get_alpha_mol(A_thole, z_mask),
+                    "alpha_species": self._thole_loss._get_alpha_mol(A_thole, z_mask)[0],
                     "alpha_qm": alpha,
                 }
             )
@@ -719,7 +719,7 @@ class EMLETrainer:
             )
             plot_data["alpha_reference"] = self._thole_loss._get_alpha_mol(
                 A_thole, z_mask
-            )
+            )[0]
 
             if alpha_atomic is not None:
                 plot_data["alpha_atomic_reference_emle"] = (

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "bin/emle-stop",
         "bin/emle-train",
         "bin/orca",
+        'bin/tarball-to-extxyz',
     ],
     include_package_data=True,
     url="https://github.com/chemle/emle-engine",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "bin/emle-stop",
         "bin/emle-train",
         "bin/orca",
-        'bin/tarball-to-extxyz',
+        "bin/tarball-to-extxyz",
     ],
     include_package_data=True,
     url="https://github.com/chemle/emle-engine",

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -31,7 +31,9 @@ def data():
     return atomic_numbers, xyz
 
 
-@pytest.mark.xfail(reason="SQM from the conda-forge AmberTools pacakge is currently broken.")
+@pytest.mark.xfail(
+    reason="SQM from the conda-forge AmberTools pacakge is currently broken."
+)
 def test_sqm(data):
     """
     Test the SQM backend.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,4 @@
+import os
 import numpy
 import pytest
 import torch
@@ -66,6 +67,9 @@ try:
     has_e3nn = True
 except:
     has_e3nn = False
+
+MACE_EMLE_MODEL = "tests/input/mace-emle.model"
+has_emle_mace_model = os.path.exists(MACE_EMLE_MODEL)
 
 
 @pytest.mark.parametrize("alpha_mode", ["species", "reference"])
@@ -172,6 +176,36 @@ def test_mace(alpha_mode, mace_model, atomic_numbers, charges_mm, xyz_qm, xyz_mm
         model = MACEEMLE(alpha_mode=alpha_mode)
     except RuntimeError as e:
         pytest.skip(f"MACE model unavailable: {e}")
+
+    # Make sure the model can be converted to TorchScript.
+    model = torch.jit.script(model)
+
+    # Get the energy and gradients.
+    energy = model(atomic_numbers, charges_mm, xyz_qm, xyz_mm)
+    grad_qm, grad_mm = torch.autograd.grad(energy.sum(), (xyz_qm, xyz_mm))
+
+    # Test batched inputs.
+    energy = model(
+        atomic_numbers.unsqueeze(0).repeat(2, 1),
+        charges_mm.unsqueeze(0).repeat(2, 1),
+        xyz_qm.unsqueeze(0).repeat(2, 1, 1),
+        xyz_mm.unsqueeze(0).repeat(2, 1, 1),
+    )
+
+
+@pytest.mark.skipif(not has_mace, reason="mace-torch not installed")
+@pytest.mark.skipif(not has_e3nn, reason="e3nn not installed")
+@pytest.mark.skipif(not has_emle_mace_model, reason="Test emle-mace model not found")
+def test_emle_mace(atomic_numbers, charges_mm, xyz_qm, xyz_mm):
+    """
+    Check that we can instantiate MACEEMLEJoint models, convert to TorchScript,
+    then compute energies and gradients.
+    """
+    # Instantiate the MACEEMLEJoint model.
+    try:
+        model = MACEEMLEJoint(mace_model=MACE_EMLE_MODEL)
+    except RuntimeError as e:
+        pytest.skip(f"MACEEMLEJoint model unavailable: {e}")
 
     # Make sure the model can be converted to TorchScript.
     model = torch.jit.script(model)

--- a/versioneer.py
+++ b/versioneer.py
@@ -301,6 +301,7 @@ https://img.shields.io/travis/com/python-versioneer/python-versioneer.svg
 [travis-url]: https://travis-ci.com/github/python-versioneer/python-versioneer
 
 """
+
 # pylint:disable=invalid-name,import-outside-toplevel,missing-function-docstring
 # pylint:disable=missing-class-docstring,too-many-branches,too-many-statements
 # pylint:disable=raise-missing-from,too-many-lines,too-many-locals,import-error
@@ -514,9 +515,7 @@ def run_command(
     return stdout, process.returncode
 
 
-LONG_VERSION_PY[
-    "git"
-] = r'''
+LONG_VERSION_PY["git"] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build


### PR DESCRIPTION
## New backend: `emle-mace`

A new `MACEEMLEJoint` model class (`emle/models/_mace.py`) wraps an `EnergyEMLEMACE` model and computes static and induced EMLE energy components directly from its outputs, without requiring a separate EMLE model file.

`EMLECalculator` now supports `backend="emle-mace"` and routes to `MACEEMLEJoint`.

A new `use_dipoles` flag is introduced in `EMLECalculator` (propagated to `emle-server` via `EMLE_USE_DIPOLES`) to enable static atomic dipoles. This feature requires an equivariant model and is currently only supported by `emle-mace` backend.

The `EnergyEMLEMACE` model implementation and training protocol is hosted in a separate repository:  
https://github.com/kzinovjev/emle-mace  
The refactoring required to interface `emle-engine` with `emle-mace` package was performed with Claude Code (Sonnet 4.6) based on interface with previous `EnergyEMLEMACE` implementation directly in a fork of `mace` package.

`emle-mace` is an optional dependency; existing backends remain unaffected if it is not installed.

---

## EnergyEMLEMACE model loading

- `MACEEMLE` and `MACEEMLEJoint` detect `EnergyEMLEMACE` checkpoints via the model class name and dispatch to `extract_config_emle_mace_model` (from `emle-mace`) for config extraction. All other models fall back to the standard MACE extractor.  
- `EnergyEMLEMACE` is injected into `mace.modules.models` at import time, enabling `torch.load()` to deserialize checkpoints without modifying the MACE package.  
- Compiled models (`TorchScript` / `RecursiveScriptModule`) are handled by reusing the loaded module directly, bypassing config extraction (unsupported for compiled models).  
- `torch.load(..., weights_only=False)` is now explicitly used for local files to support PyTorch 2.6+.  
- `torch.serialization.add_safe_globals([slice])` is added to allow `e3nn` (which stores a `slice` in `constants.pt`) to load under PyTorch 2.6+ without requiring `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD`.

---

## Static atomic dipoles support in EMLE

- `EMLE.forward` now accepts an `external_params` argument, allowing callers to provide precomputed EMLE properties:
  - `s`, `q_core`, `q_val`, `mu`, `k_Z`, `a_Thole`  
  instead of running `EMLEBase`.  

- `EMLEBase.get_static_energy` now accepts an optional `mu` argument. When provided, the dipole contribution (`vpot_mu`) is included in the electrostatic energy.  

This mechanism is used by `MACEEMLEJoint` to incorporate static atomic dipoles predicted by `EnergyEMLEMACE`.

---

## EMLEAnalyzer improvements

- Added support for `emle-mace` backend:
  - EMLE properties (`s`, `q_core`, `q`, `q_val`, `mu`) are read from `backend.emle_values`.  
  - Thole matrix is reconstructed from learned model parameters.  

- MACE gradients (`grad_backend`) are computed via `torch.autograd.grad` and exported.  
- Static dipole energy (`e_static_mu`) is computed and exported when `use_dipoles=True`.  
- `q` and `mu` are now included in exported outputs.  
- Backend calls now pass `qm_charge` explicitly.

---

## ORCA data utilities

- New `ORCAParser` methods:
  - `get_E_vac` — parses vacuum energies  
  - `get_forces` — parses Cartesian gradients (converted to forces in eV/Å)  

  These are automatically invoked during parsing.

- Removed module-local `_HARTREE_TO_KCALMOL`; all unit conversions now use the shared `_units` module.  
- Added `_HARTREE_BOHR_TO_EV_A` constant to `_units.py`.  

- New module: `emle/_tarball_to_extXYZ.py`
  - Provides `orca_to_extxyz()` to convert ORCA tarballs to `extXYZ` format using `ORCAParser` and ASE.  
  - Outputs energies, forces, and EMLE properties as per-atom arrays and metadata fields.  

- New CLI entry point:
  ```bash
  bin/tarball-to-extxyz