### PR TITLE
Fix EMLEAnalyzer broken for non-torch backends

### DIFF
--- a/emle/_analyzer.py
+++ b/emle/_analyzer.py
@@ -152,13 +152,22 @@ class EMLEAnalyzer:
                 )
                 charges_mm = _torch.empty((len(qm_xyz), 0), dtype=dtype, device=device)
                 mm_xyz = _torch.empty((len(qm_xyz), 0, 3), dtype=dtype, device=device)
-            self.e_backend = (
-                backend(atomic_numbers, charges_mm, qm_xyz, mm_xyz, qm_charge=q_total).T
-                * _HARTREE_TO_KCAL_MOL
-            )
-            self.grad_backend = _torch.autograd.grad(self.e_backend.T[0].sum(), qm_xyz)[
-                0
-            ]
+                self.e_backend = (
+                    backend(
+                        atomic_numbers, charges_mm, qm_xyz, mm_xyz, qm_charge=q_total
+                    ).T
+                    * _HARTREE_TO_KCAL_MOL
+                )
+                self.grad_backend = _torch.autograd.grad(
+                    self.e_backend.T[0].sum(), qm_xyz
+                )[0]
+            else:
+                # Non-torch backend (no autograd): gradient = -forces.
+                e, f = backend(atomic_numbers, qm_xyz)
+                self.e_backend = _torch.from_numpy(e * _HARTREE_TO_KCAL_MOL)[:, None]
+                self.grad_backend = _torch.from_numpy(
+                    -f * _ANGSTROM_TO_BOHR * _HARTREE_TO_KCAL_MOL
+                )
 
         self.atomic_numbers = _torch.tensor(
             atomic_numbers, dtype=_torch.int, device=device


### PR DESCRIPTION
`emle-analyze` currently crashes when used with a non-torch backend such as DeePMD. This PR restores the non-torch path while leaving the torch path unchanged.