### PR TITLE
Rename species/reference to fixed/flexible system-wide

### DIFF
--- a/bin/emle-analyze
+++ b/bin/emle-analyze
@@ -63,9 +63,12 @@ parser.add_argument(
 parser.add_argument(
     "--alpha-mode",
     type=str,
-    choices=["species", "reference"],
-    default="species",
-    help="Method for calculating atomic polarizabilities",
+    choices=["fixed", "flexible", "species", "reference"],
+    default="fixed",
+    help=(
+        "Method for calculating atomic polarizabilities. "
+        "('species'/'reference' are deprecated aliases for 'fixed'/'flexible')"
+    ),
 )
 parser.add_argument(
     "--alpha", action="store_true", help="Extract molecular dipolar polarizabilities"

--- a/bin/emle-compile
+++ b/bin/emle-compile
@@ -98,8 +98,11 @@ def _build_parser():
     )
     p.add_argument(
         "--alpha-mode", type=str, required=False,
-        choices=["species", "reference"],
-        help="Polarizability mode. Default: species."
+        choices=["fixed", "flexible", "species", "reference"],
+        help=(
+            "Polarizability mode. Default: fixed. "
+            "('species'/'reference' are deprecated aliases for 'fixed'/'flexible')"
+        )
     )
     p.add_argument(
         "--atomic-numbers", type=str, nargs="*", required=False,
@@ -185,7 +188,7 @@ def main(argv=None):
     if args.get("method") is None:
         args["method"] = "electrostatic"
     # alpha_mode default is resolved inside EMLECompiler so the emle-mace
-    # backend can reject an explicit non-"species" choice.
+    # backend can reject an explicit non-"fixed" choice.
     if args.get("qm_charge") is None:
         args["qm_charge"] = 0
 

--- a/bin/emle-server
+++ b/bin/emle-server
@@ -218,8 +218,11 @@ parser.add_argument(
 parser.add_argument(
     "--alpha-mode",
     type=str,
-    help="the alpha mode to use for the embedding method",
-    choices=["species", "reference"],
+    help=(
+        "the alpha mode to use for the embedding method "
+        "('species'/'reference' are deprecated aliases for 'fixed'/'flexible')"
+    ),
+    choices=["fixed", "flexible", "species", "reference"],
     required=False,
 )
 parser.add_argument(

--- a/doc/source/dynamics.rst
+++ b/doc/source/dynamics.rst
@@ -248,8 +248,8 @@ Alpha mode
 ----------
 
 We support two methods for the calculation of atomic polarisabilities. The default,
-``species``, uses a single volume scaling factor for each species. Alternatively,
-``reference``, calculates the scaling factors using Gaussian Process Regression
+``fixed``, uses a single volume scaling factor for each species. Alternatively,
+``flexible``, calculates the scaling factors using Gaussian Process Regression
 (GPR) using the values learned for each reference environment. The alpha mode can
 be specified using the ``--alpha-mode`` command-line argument, or via the
 ``EMLE_ALPHA_MODE`` environment variable.

--- a/emle/_compiler.py
+++ b/emle/_compiler.py
@@ -31,6 +31,8 @@ from typing import List, Optional, Tuple, Union
 import torch as _torch
 from torch import Tensor as _Tensor
 
+from .models._utils import _sanitize_alpha_mode
+
 
 class _CustomMLMMWrapper(_torch.nn.Module):
     """Adapts an EMLE composite (ANI2xEMLE / MACEEMLE) to the torchani-amber
@@ -127,8 +129,8 @@ class EMLECompiler:
             ``"nonpol"``, or ``"mm"``.
 
         alpha_mode : str, optional
-            Polarizability mode: ``"species"`` or ``"reference"``. Defaults
-            to ``"species"`` when omitted. Must be ``"species"`` (or omitted)
+            Polarizability mode: ``"fixed"`` or ``"flexible"``. Defaults
+            to ``"fixed"`` when omitted. Must be ``"fixed"`` (or omitted)
             for the ``"emle-mace"`` backend, which hard-codes that mode.
 
         atomic_numbers : list of int, optional
@@ -181,15 +183,17 @@ class EMLECompiler:
         if use_dipoles and backend != "emle-mace":
             raise ValueError("'use_dipoles' is only valid for backend='emle-mace'.")
 
+        alpha_mode = _sanitize_alpha_mode(alpha_mode, default=None)
+
         if backend == "emle-mace":
-            if alpha_mode is not None and alpha_mode != "species":
+            if alpha_mode is not None and alpha_mode != "fixed":
                 raise ValueError(
-                    "backend='emle-mace' requires alpha_mode='species' "
-                    "(MACEEMLEJoint hard-codes the species mode)."
+                    "backend='emle-mace' requires alpha_mode='fixed' "
+                    "(MACEEMLEJoint hard-codes the fixed mode)."
                 )
         else:
             if alpha_mode is None:
-                alpha_mode = "species"
+                alpha_mode = "fixed"
 
         self._device = _torch.device(device) if device else _torch.device("cpu")
         self._composite = self._build_composite(

--- a/emle/calculator.py
+++ b/emle/calculator.py
@@ -79,7 +79,7 @@ class EMLECalculator:
         self,
         model=None,
         method="electrostatic",
-        alpha_mode="species",
+        alpha_mode="fixed",
         use_dipoles=False,
         atomic_numbers=None,
         qm_charge=0,
@@ -149,9 +149,9 @@ class EMLECalculator:
 
         alpha_mode: str
             How atomic polarizabilities are calculated.
-                "species":
+                "fixed":
                     one volume scaling factor is used for each species
-                "reference":
+                "flexible":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
 

--- a/emle/models/_ani.py
+++ b/emle/models/_ani.py
@@ -73,7 +73,7 @@ class ANI2xEMLE(_torch.nn.Module):
         self,
         emle_model=None,
         emle_method="electrostatic",
-        alpha_mode="species",
+        alpha_mode="fixed",
         mm_charges=None,
         qm_charge=0,
         model_index=None,
@@ -107,9 +107,9 @@ class ANI2xEMLE(_torch.nn.Module):
 
         alpha_mode: str
             How atomic polarizabilities are calculated.
-                "species":
+                "fixed":
                     one volume scaling factor is used for each species
-                "reference":
+                "flexible":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
 

--- a/emle/models/_deepmd.py
+++ b/emle/models/_deepmd.py
@@ -58,7 +58,7 @@ class DeePMDEMLE(_torch.nn.Module):
         self,
         emle_model=None,
         emle_method="electrostatic",
-        alpha_mode="species",
+        alpha_mode="fixed",
         mm_charges=None,
         qm_charge=0,
         deepmd_model=None,

--- a/emle/models/_emle.py
+++ b/emle/models/_emle.py
@@ -37,6 +37,7 @@ from torch import Tensor
 from typing import Union, Optional, Dict
 
 from . import EMLEBase as _EMLEBase
+from ._utils import _sanitize_alpha_mode
 
 try:
     import NNPOps as _NNPOps
@@ -73,7 +74,7 @@ class EMLE(_torch.nn.Module):
         self,
         model=None,
         method="electrostatic",
-        alpha_mode="species",
+        alpha_mode="fixed",
         atomic_numbers=None,
         qm_charge=0,
         mm_charges=None,
@@ -108,9 +109,9 @@ class EMLE(_torch.nn.Module):
 
         alpha_mode: str
             How atomic polarizabilities are calculated.
-                "species":
+                "fixed":
                     one volume scaling factor is used for each species
-                "reference":
+                "flexible":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
 
@@ -161,14 +162,7 @@ class EMLE(_torch.nn.Module):
             )
         self._method = method
 
-        if alpha_mode is None:
-            alpha_mode = "species"
-        if not isinstance(alpha_mode, str):
-            raise TypeError("'alpha_mode' must be of type 'str'")
-        alpha_mode = alpha_mode.lower().replace(" ", "")
-        if alpha_mode not in ["species", "reference"]:
-            raise ValueError("'alpha_mode' must be 'species' or 'reference'")
-        self._alpha_mode = alpha_mode
+        self._alpha_mode = _sanitize_alpha_mode(alpha_mode)
 
         if atomic_numbers is not None:
             if isinstance(atomic_numbers, (_np.ndarray, _torch.Tensor)):

--- a/emle/models/_emle_base.py
+++ b/emle/models/_emle_base.py
@@ -36,6 +36,8 @@ from typing import Tuple, Optional
 
 import torchani as _torchani
 
+from ._utils import _sanitize_alpha_mode
+
 try:
     import NNPOps as _NNPOps
 
@@ -65,7 +67,7 @@ class EMLEBase(_torch.nn.Module):
         q_core,
         emle_aev_computer=None,
         species=None,
-        alpha_mode="species",
+        alpha_mode="fixed",
         device=None,
         dtype=None,
     ):
@@ -89,9 +91,9 @@ class EMLEBase(_torch.nn.Module):
 
         alpha_mode: str
             How atomic polarizabilities are calculated.
-                "species":
+                "fixed":
                     one volume scaling factor is used for each species
-                "reference":
+                "flexible":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environment
 
@@ -151,14 +153,7 @@ class EMLEBase(_torch.nn.Module):
             )
 
         # Validate the alpha mode.
-        if alpha_mode is None:
-            alpha_mode = "species"
-        if not isinstance(alpha_mode, str):
-            raise TypeError("'alpha_mode' must be of type 'str'")
-        alpha_mode = alpha_mode.lower().replace(" ", "")
-        if alpha_mode not in ["species", "reference"]:
-            raise ValueError("'alpha_mode' must be 'species' or 'reference'")
-        self._alpha_mode = alpha_mode
+        self._alpha_mode = _sanitize_alpha_mode(alpha_mode)
 
         # Validate the AEV computer.
         if emle_aev_computer is not None:
@@ -196,13 +191,13 @@ class EMLEBase(_torch.nn.Module):
         self.ref_values_chi = _torch.nn.Parameter(params["ref_values_chi"])
         self.k_Z = _torch.nn.Parameter(params["k_Z"])
 
-        if self._alpha_mode == "reference":
+        if self._alpha_mode == "flexible":
             try:
                 self.ref_values_sqrtk = _torch.nn.Parameter(params["sqrtk_ref"])
             except:
                 msg = (
                     "Missing 'sqrtk_ref' key in params. This is required when "
-                    "using 'reference' alpha mode."
+                    "using 'flexible' alpha mode."
                 )
                 raise ValueError(msg)
 
@@ -236,7 +231,7 @@ class EMLEBase(_torch.nn.Module):
         ref_mean_s, c_s = self._get_c(n_ref, self.ref_values_s, Kinv)
         ref_mean_chi, c_chi = self._get_c(n_ref, self.ref_values_chi, Kinv)
 
-        if self._alpha_mode == "species":
+        if self._alpha_mode == "fixed":
             ref_mean_sqrtk = _torch.zeros_like(ref_mean_s, dtype=dtype, device=device)
             c_sqrtk = _torch.zeros_like(c_s, dtype=dtype, device=device)
         else:
@@ -435,7 +430,7 @@ class EMLEBase(_torch.nn.Module):
 
         k = self.k_Z[species_id]
 
-        if self._alpha_mode == "reference":
+        if self._alpha_mode == "flexible":
             k_scale = (
                 self._gpr(aev, self._ref_mean_sqrtk, self._c_sqrtk, species_id) ** 2
             )

--- a/emle/models/_mace.py
+++ b/emle/models/_mace.py
@@ -98,7 +98,7 @@ class MACEEMLE(_torch.nn.Module):
         self,
         emle_model=None,
         emle_method="electrostatic",
-        alpha_mode="species",
+        alpha_mode="fixed",
         mm_charges=None,
         qm_charge=0,
         mace_model=None,
@@ -131,9 +131,9 @@ class MACEEMLE(_torch.nn.Module):
 
         alpha_mode: str
             How atomic polarizabilities are calculated.
-                "species":
+                "fixed":
                     one volume scaling factor is used for each species
-                "reference":
+                "flexible":
                     scaling factors are obtained with GPR using the values learned
                     for each reference environmentw
 
@@ -845,13 +845,12 @@ class MACEEMLEJoint(_torch.nn.Module):
             )
 
         # Create an instance of the EMLE model.
-        # alpha_mode is fixed to "species" here: MACEEMLEJoint currently only
-        # supports the species mode. Re-expose as a parameter once reference
-        # mode is wired through MACE.
+        # alpha_mode is hard-coded to "fixed" here: MACEEMLEJoint currently only
+        # supports the fixed mode.
         self._emle = _EMLE(
             model=emle_model,
             method=emle_method,
-            alpha_mode="species",
+            alpha_mode="fixed",
             atomic_numbers=(atomic_numbers if atomic_numbers is not None else None),
             mm_charges=mm_charges,
             qm_charge=qm_charge,

--- a/emle/models/_utils.py
+++ b/emle/models/_utils.py
@@ -27,12 +27,34 @@ __email__ = "lester.hedges@gmail.com"
 
 import torch as _torch
 
+from loguru import logger as _logger
+
 from typing import Optional, Tuple
 
 try:
     import NNPOps.neighbors.getNeighborPairs as _getNeighborPairs
 except:
     pass
+
+
+_DEPRECATED_ALPHA_MODES = {"species": "fixed", "reference": "flexible"}
+
+
+def _sanitize_alpha_mode(alpha_mode, default="fixed"):
+    if alpha_mode is None:
+        return default
+    if not isinstance(alpha_mode, str):
+        raise TypeError("'alpha_mode' must be of type 'str'")
+    alpha_mode = alpha_mode.lower().replace(" ", "")
+    if alpha_mode in _DEPRECATED_ALPHA_MODES:
+        new_mode = _DEPRECATED_ALPHA_MODES[alpha_mode]
+        _logger.warning(
+            f"alpha_mode='{alpha_mode}' is deprecated; use '{new_mode}' instead."
+        )
+        alpha_mode = new_mode
+    if alpha_mode not in ("fixed", "flexible"):
+        raise ValueError("'alpha_mode' must be 'fixed' or 'flexible'")
+    return alpha_mode
 
 
 def _get_neighbor_pairs(

--- a/emle/train/_loss.py
+++ b/emle/train/_loss.py
@@ -24,6 +24,8 @@
 
 import torch as _torch
 
+from ..models._utils import _sanitize_alpha_mode
+
 
 class _BaseLoss(_torch.nn.Module):
     """
@@ -165,8 +167,8 @@ class TholeLoss(_BaseLoss):
     emle_base: EMLEBase
         EMLEBase object.
 
-    mode: str, optional, default='species'
-        Alpha mode. Either 'species' or 'reference'.
+    mode: str, optional, default='fixed'
+        Alpha mode. Either 'fixed' or 'flexible'.
 
     loss: torch.nn.Module, optional, default=torch.nn.MSELoss()
         Loss function.
@@ -181,7 +183,7 @@ class TholeLoss(_BaseLoss):
         Loss function.
     """
 
-    def __init__(self, emle_base, mode="species", loss=_torch.nn.MSELoss()):
+    def __init__(self, emle_base, mode="fixed", loss=_torch.nn.MSELoss()):
         super().__init__()
 
         from ..models._emle_base import EMLEBase
@@ -274,12 +276,9 @@ class TholeLoss(_BaseLoss):
         Parameters
         ----------
         mode: str
-            Alpha mode. Either 'species' or 'reference'.
+            Alpha mode. Either 'fixed' or 'flexible'.
         """
-        mode = mode.lower().replace(" ", "")
-        if mode not in ("species", "reference"):
-            raise ValueError("TholeLoss: mode must be either 'species' or 'reference'")
-        self._emle_base.alpha_mode = mode
+        self._emle_base.alpha_mode = _sanitize_alpha_mode(mode)
 
     def forward(
         self,

--- a/emle/train/_trainer.py
+++ b/emle/train/_trainer.py
@@ -28,6 +28,7 @@ import torch as _torch
 from ..models import EMLEAEVComputer as _EMLEAEVComputer
 from ..models import EMLEBase as _EMLEBase
 from ..models import EMLE
+from ..models._utils import _sanitize_alpha_mode
 from ._gpr import GPR as _GPR
 from ._ivm import IVM as _IVM
 from ._loss import QEqLoss as _QEqLoss
@@ -297,7 +298,7 @@ class EMLETrainer:
         alpha=None,
         train_mask=None,
         alpha_atomic=None,
-        alpha_mode="reference",
+        alpha_mode="flexible",
         sigma=1e-3,
         ivm_thr=0.05,
         epochs=100,
@@ -350,7 +351,7 @@ class EMLETrainer:
         train_mask: torch.Tensor(N_BATCH,)
             Mask for training samples.
 
-        alpha_mode: 'species' or 'reference'
+        alpha_mode: 'fixed' or 'flexible'
             Mode for polarizability model.
 
         sigma: float
@@ -373,7 +374,7 @@ class EMLETrainer:
 
         l2_reg_thole: float
             L2 regularization coefficient for Thole model training.
-            Only relevant if alpha_mode is 'reference'.
+            Only relevant if alpha_mode is 'flexible'.
 
         weight_alpha_mol: float
             Weight of molecular polarizabilities in the loss function.
@@ -435,11 +436,7 @@ class EMLETrainer:
             )
 
         # Checks for alpha_mode.
-        if not isinstance(alpha_mode, str):
-            raise TypeError("'alpha_mode' must be of type 'str'")
-        alpha_mode = alpha_mode.lower().replace(" ", "")
-        if alpha_mode not in ["species", "reference"]:
-            raise ValueError("'alpha_mode' must be 'species' or 'reference'")
+        alpha_mode = _sanitize_alpha_mode(alpha_mode, default="flexible")
 
         if train_mask is None:
             train_mask = _torch.ones(len(z), dtype=_torch.bool)
@@ -564,7 +561,7 @@ class EMLETrainer:
                         dtype=ref_values_s.dtype,
                         device=_torch.device(device),
                     )
-                    if alpha_mode == "reference"
+                    if alpha_mode == "flexible"
                     else None
                 ),
             }
@@ -631,7 +628,7 @@ class EMLETrainer:
             _logger.debug(f"Optimized a_Thole: {emle_base.a_Thole.data.item()}")
 
             # Fit sqrtk_ref ( alpha = sqrtk ** 2 * k_Z * v).
-            if alpha_mode == "reference":
+            if alpha_mode == "flexible":
                 _logger.info("Fitting ref_values_sqrtk values...")
                 self._train_model(
                     loss_class=self._thole_loss,
@@ -661,7 +658,7 @@ class EMLETrainer:
             "chi_ref": emle_base.ref_values_chi,
             "k_Z": emle_base.k_Z,
             "sqrtk_ref": (
-                emle_base.ref_values_sqrtk if alpha_mode == "reference" else None
+                emle_base.ref_values_sqrtk if alpha_mode == "flexible" else None
             ),
             "species": emle_base._species,
             "alpha_mode": emle_base._alpha_mode,
@@ -678,7 +675,7 @@ class EMLETrainer:
         if plot_data_filename is None:
             return emle_base
 
-        emle_base._alpha_mode = "species"
+        emle_base._alpha_mode = "fixed"
         s_pred, q_core_pred, q_val_pred, A_thole, *_ = emle_base(
             z.to(device=device, dtype=_torch.int64),
             xyz.to(device=device, dtype=dtype),
@@ -699,32 +696,30 @@ class EMLETrainer:
         if train_thole:
             plot_data.update(
                 {
-                    "alpha_species": self._thole_loss._get_alpha_mol(A_thole, z_mask)[
-                        0
-                    ],
+                    "alpha_fixed": self._thole_loss._get_alpha_mol(A_thole, z_mask)[0],
                     "alpha_qm": alpha,
                 }
             )
 
         if alpha_atomic is not None:
             plot_data["alpha_atomic_qm"] = alpha_atomic
-            plot_data["alpha_atomic_species_emle"] = self._thole_loss._get_alpha_atomic(
+            plot_data["alpha_atomic_fixed_emle"] = self._thole_loss._get_alpha_atomic(
                 A_thole, z_mask
             )
 
-        if alpha_mode == "reference":
-            emle_base._alpha_mode = "reference"
+        if alpha_mode == "flexible":
+            emle_base._alpha_mode = "flexible"
             *_, A_thole = emle_base(
                 z.to(device=device, dtype=_torch.int64),
                 xyz.to(device=device, dtype=dtype),
                 q_mol,
             )
-            plot_data["alpha_reference"] = self._thole_loss._get_alpha_mol(
+            plot_data["alpha_flexible"] = self._thole_loss._get_alpha_mol(
                 A_thole, z_mask
             )[0]
 
             if alpha_atomic is not None:
-                plot_data["alpha_atomic_reference_emle"] = (
+                plot_data["alpha_atomic_flexible_emle"] = (
                     self._thole_loss._get_alpha_atomic(A_thole, z_mask)
                 )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -141,7 +141,7 @@ def deepmd_model_path_partial_typemap(tmp_path_factory):
 # Reference values computed with float64 to serve as a regression baseline
 # for the EMLE single-point energy and gradients.
 _EMLE_REFERENCE = {
-    "species": {
+    "fixed": {
         "energy": [-0.04694829706768215, -0.008400531962381722],
         "grad_qm_0": [0.003351301543246329, 0.0018965630117571137, -0.0041146694189497],
         "grad_mm_0": [
@@ -150,7 +150,7 @@ _EMLE_REFERENCE = {
             -0.0005122610976422208,
         ],
     },
-    "reference": {
+    "flexible": {
         "energy": [-0.04694829706768215, -0.008116915512224699],
         "grad_qm_0": [
             0.0028342878810772108,
@@ -166,7 +166,7 @@ _EMLE_REFERENCE = {
 }
 
 
-@pytest.mark.parametrize("alpha_mode", ["species", "reference"])
+@pytest.mark.parametrize("alpha_mode", ["fixed", "flexible"])
 def test_emle_single_point(alpha_mode):
     """
     Regression test: checks that the EMLE model produces the expected
@@ -223,7 +223,7 @@ def test_emle_single_point(alpha_mode):
         ), f"grad_mm[0,{j}] mismatch: got {grad_mm[0,j].item()}, expected {expected}"
 
 
-@pytest.mark.parametrize("alpha_mode", ["species", "reference"])
+@pytest.mark.parametrize("alpha_mode", ["fixed", "flexible"])
 def test_emle(alpha_mode, atomic_numbers, charges_mm, xyz_qm, xyz_mm):
     """
     Check that we can instantiate the default EMLE model, convert
@@ -248,7 +248,7 @@ def test_emle(alpha_mode, atomic_numbers, charges_mm, xyz_qm, xyz_mm):
     )
 
 
-@pytest.mark.parametrize("alpha_mode", ["species", "reference"])
+@pytest.mark.parametrize("alpha_mode", ["fixed", "flexible"])
 def test_ani2x(alpha_mode, atomic_numbers, charges_mm, xyz_qm, xyz_mm):
     """
     Check that we can instantiate the default ANI2xEMLE model,
@@ -285,7 +285,7 @@ def test_ani2x(alpha_mode, atomic_numbers, charges_mm, xyz_qm, xyz_mm):
 
 
 @pytest.mark.skipif(not has_nnpops, reason="NNPOps not installed")
-@pytest.mark.parametrize("alpha_mode", ["species", "reference"])
+@pytest.mark.parametrize("alpha_mode", ["fixed", "flexible"])
 def test_ani2x_nnpops(alpha_mode, atomic_numbers, charges_mm, xyz_qm, xyz_mm):
     """
     Check that we can instantiate the default ANI2xEMLE model with NNPOps,
@@ -314,7 +314,7 @@ def test_ani2x_nnpops(alpha_mode, atomic_numbers, charges_mm, xyz_qm, xyz_mm):
 @pytest.mark.skipif(not has_mace, reason="mace-torch not installed")
 @pytest.mark.skipif(not has_e3nn, reason="e3nn not installed")
 @pytest.mark.skipif(not has_nnpops, reason="NNPOps not installed")
-@pytest.mark.parametrize("alpha_mode", ["species", "reference"])
+@pytest.mark.parametrize("alpha_mode", ["fixed", "flexible"])
 @pytest.mark.parametrize(
     "mace_model", ["mace-off23-small", "mace-off23-medium", "mace-off23-large"]
 )


### PR DESCRIPTION
Renames the `alpha_mode` values from `species`/`reference` to `fixed`/`flexible`.

- `fixed`/`flexible` are now the canonical values used everywhere internally.
- CLI tools and class constructors still accept `species`/`reference`, but emit a deprecation warning (translated to `fixed`/`flexible` via a shared helper).
- Old `.mat` model files load unchanged.
